### PR TITLE
render real data in card

### DIFF
--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -12,15 +12,18 @@ export type CardComponent = typeof _CardComponent;
 export type Format = 'isolated' | 'embedded' | 'edit';
 
 export class Card {
+  data: Record<string, any>;
   isolated: CardComponent;
   edit: CardComponent;
   embedded: CardComponent;
 
   constructor(params: {
+    data?: Record<string, any>;
     isolated?: CardComponent;
     edit?: CardComponent;
     embedded?: CardComponent;
   }) {
+    this.data = params.data || {};
     this.isolated = params.isolated ?? _CardComponent;
     this.edit = params.edit ?? _CardComponent;
     this.embedded = params.embedded ?? _CardComponent;
@@ -34,17 +37,17 @@ export class Card {
 class _Wrapper extends Component {}
 
 export class CardView {
-  constructor(card: Card, format: Format) {
+  constructor(private card: Card, format: Format) {
     let CardComponent = card[format];
     let self: CardView = this;
     this.component = class Wrapper extends Component {
-      <template><CardComponent @model={{self.model}} /></template>
+      <template><CardComponent @model={{self.data}} /></template>
     }
   }
 
   component: typeof _Wrapper;
 
-  get model() {
-    return { title: 'the title' };
+  get data() {
+    return this.card.data;
   }
 }

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -11,10 +11,11 @@ class _CardComponent extends Component<Signature> {}
 export type CardComponent = typeof _CardComponent;
 export type Format = 'isolated' | 'embedded' | 'edit';
 
-class _Schema {
-  // TODO add schema members here...
+export class SchemaClass {
+  // TODO probably wanna use a WeakMap here so we don't leak this
+  fields: Record<string, Card> = {};
 }
-export type Schema = typeof _Schema;
+export type Schema = typeof SchemaClass;
 
 export class Card {
   data: Record<string, any>;
@@ -31,7 +32,7 @@ export class Card {
     embedded?: CardComponent;
   }) {
     this.data = params.data || {};
-    this.schema = params.schema ?? _Schema;
+    this.schema = params.schema ?? SchemaClass;
     this.isolated = params.isolated ?? _CardComponent;
     this.edit = params.edit ?? _CardComponent;
     this.embedded = params.embedded ?? _CardComponent;
@@ -51,6 +52,7 @@ export class CardView {
     this.component = class Wrapper extends Component {
       <template><CardComponent @model={{self.data}}/></template>
     }
+    // TODO map over this.card.schema.fields assigning the @contains card for each...
   }
 
   component: typeof _Wrapper;
@@ -60,9 +62,8 @@ export class CardView {
   }
 }
 
-export function contains(_field: Card) {
-  // TODO unsure how to wire this up....
-  return function(_target: _Schema, _key: string) {
-
+export function contains(fieldMaker: () => Card) {
+  return function(target: SchemaClass, key: string) {
+    target.fields[key] = fieldMaker();
   }
 }

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -62,7 +62,7 @@ export class CardView {
 
 export function contains(field: Card) {
   // TODO unsure how to wire this up....
-  return function(target, key) {
+  return function(target: _Schema, key: string) {
 
   }
 }

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -2,7 +2,7 @@ import Component from '@glint/environment-ember-loose/glimmer-component';
 
 export interface Signature {
   Args: {
-    model: Record<string, any>;
+    model: Record<string, any> | any;
   };
 }
 
@@ -11,19 +11,27 @@ class _CardComponent extends Component<Signature> {}
 export type CardComponent = typeof _CardComponent;
 export type Format = 'isolated' | 'embedded' | 'edit';
 
+class _Schema {
+  // TODO add schema members here...
+}
+export type Schema = typeof _Schema;
+
 export class Card {
   data: Record<string, any>;
+  schema: Schema;
   isolated: CardComponent;
   edit: CardComponent;
   embedded: CardComponent;
 
   constructor(params: {
     data?: Record<string, any>;
+    schema?: Schema;
     isolated?: CardComponent;
     edit?: CardComponent;
     embedded?: CardComponent;
   }) {
     this.data = params.data || {};
+    this.schema = params.schema ?? _Schema;
     this.isolated = params.isolated ?? _CardComponent;
     this.edit = params.edit ?? _CardComponent;
     this.embedded = params.embedded ?? _CardComponent;
@@ -41,7 +49,7 @@ export class CardView {
     let CardComponent = card[format];
     let self: CardView = this;
     this.component = class Wrapper extends Component {
-      <template><CardComponent @model={{self.data}} /></template>
+      <template><CardComponent @model={{self.data}}/></template>
     }
   }
 
@@ -49,5 +57,12 @@ export class CardView {
 
   get data() {
     return this.card.data;
+  }
+}
+
+export function contains(field: Card) {
+  // TODO unsure how to wire this up....
+  return function(target, key) {
+
   }
 }

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -60,9 +60,9 @@ export class CardView {
   }
 }
 
-export function contains(field: Card) {
+export function contains(_field: Card) {
   // TODO unsure how to wire this up....
-  return function(target: _Schema, key: string) {
+  return function(_target: _Schema, _key: string) {
 
   }
 }

--- a/host/app/lib/string-field.gts
+++ b/host/app/lib/string-field.gts
@@ -1,0 +1,13 @@
+import { Card, Signature, } from 'runtime-spike/lib/card-api';
+import Component from '@glint/environment-ember-loose/glimmer-component';
+
+export default function() {
+  return new Card({
+    isolated: class Isolated extends Component<Signature> {
+      <template>{{@model}}</template>
+    },
+    embedded: class Embedded extends Component<Signature> {
+      <template>{{@model}}</template>
+    }
+  });
+}

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -3,10 +3,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { renderComponent } from '../../helpers/render-component';
 import { Card, Signature, SchemaClass, contains } from 'runtime-spike/lib/card-api';
 import Component from '@glint/environment-ember-loose/glimmer-component';
-import stringField from 'runtime-spike/lib/string-field';
+import string from 'runtime-spike/lib/string-field';
 
 class SimpleSchema extends SchemaClass {
-  @contains(stringField) title: string | undefined;
+  @contains(string) title: string | undefined;
 }
 
 module('Integration | card-basics', function (hooks) {

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { renderComponent } from '../../helpers/render-component';
-import { Card, Signature, contains } from 'runtime-spike/lib/card-api';
+import { Card, Signature, SchemaClass, contains } from 'runtime-spike/lib/card-api';
 import Component from '@glint/environment-ember-loose/glimmer-component';
 import stringField from 'runtime-spike/lib/string-field';
 
-class SimpleSchema {
-  @contains(stringField()) title: string | undefined;
+class SimpleSchema extends SchemaClass {
+  @contains(stringField) title: string | undefined;
 }
 
 module('Integration | card-basics', function (hooks) {

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -10,6 +10,9 @@ module('Integration | card-basics', function (hooks) {
   test('render a simple card', async function (assert) {
 
     let helloWorld = new Card({
+      data: {
+        title: 'the title'
+      },
       isolated: class Isolated extends Component<Signature> {
         <template>{{@model.title}}</template>
       }

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -1,8 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { renderComponent } from '../../helpers/render-component';
-import { Card, Signature } from 'runtime-spike/lib/card-api';
+import { Card, Signature, contains } from 'runtime-spike/lib/card-api';
 import Component from '@glint/environment-ember-loose/glimmer-component';
+import stringField from 'runtime-spike/lib/string-field';
+
+class SimpleSchema {
+  @contains(stringField()) title: string | undefined;
+}
 
 module('Integration | card-basics', function (hooks) {
   setupRenderingTest(hooks);
@@ -13,7 +18,9 @@ module('Integration | card-basics', function (hooks) {
       data: {
         title: 'the title'
       },
+      schema: SimpleSchema,
       isolated: class Isolated extends Component<Signature> {
+        // TODO change this to {{@field.title}}
         <template>{{@model.title}}</template>
       }
     });


### PR DESCRIPTION
the first commit adds live data, which works. in the second commit i attempted to sketch out what i think the schema should look like. notably, i created a simple string card and am using the string card as an argument to the `@contains()` decorator on the schema. I'm unsure how to wire it all up though.... 