### PR TITLE
Switch to glint's "native signatures"

### DIFF
--- a/host/app/components/file-tree.gts
+++ b/host/app/components/file-tree.gts
@@ -1,4 +1,4 @@
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import Component from '@glimmer/component';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';

--- a/host/app/components/go.gts
+++ b/host/app/components/go.gts
@@ -1,4 +1,4 @@
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import monaco from '../modifiers/monaco';
 import { service } from '@ember/service';

--- a/host/app/components/preview.gts
+++ b/host/app/components/preview.gts
@@ -1,4 +1,4 @@
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import Component from '@glimmer/component';
 import { importResource } from '../resources/import';
 
 export default class Preview extends Component<{ Args: { filename: string } }> {

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -1,4 +1,4 @@
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import Component from '@glimmer/component';
 
 export interface Signature {
   Args: {

--- a/host/app/modifiers/monaco.ts
+++ b/host/app/modifiers/monaco.ts
@@ -1,4 +1,4 @@
-import Modifier from '@glint/environment-ember-loose/ember-modifier';
+import Modifier from 'ember-modifier';
 import '@cardstack/requirejs-monaco-ember-polyfill';
 import * as monaco from 'monaco-editor';
 import { restartableTask, timeout } from 'ember-concurrency';

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { renderComponent } from '../../helpers/render-component';
 import { Card, Signature } from 'runtime-spike/lib/card-api';
-import Component from '@glint/environment-ember-loose/glimmer-component';
+import Component from '@glimmer/component';
 
 module('Integration | card-basics', function (hooks) {
   setupRenderingTest(hooks);

--- a/host/types/global.d.ts
+++ b/host/types/global.d.ts
@@ -1,7 +1,8 @@
 import { TemplateFactory } from 'htmlbars-inline-precompile';
-import Helper from '@glint/environment-ember-loose/ember-component/helper';
+import Helper from '@ember/component/helper';
 import '@glint/environment-ember-loose/registry';
-import GlimmerComponent from '@glimmer/component';
+import '@glint/environment-ember-loose/native-integration';
+import { ComponentLike } from '@glint/template';
 
 // Types for compiled templates
 declare module 'runtime-spike/templates/*' {
@@ -16,7 +17,7 @@ declare global {
 declare module '@ember/component' {
   export function setComponentTemplate(
     template: string,
-    Component: typeof GlimmerComponent
+    Component: ComponentLike
   ): void;
 }
 


### PR DESCRIPTION
Following https://typed-ember.gitbook.io/glint/using-glint/migrating#native-signatures-and-imports I was able to upgrade us to use the real import paths for @glimmer/component, etc.