### PR TITLE
Card serialization

### DIFF
--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -191,13 +191,21 @@ function getInitialData(card: Constructable): Record<string, any> | undefined {
   return (card as any).data;
 }
 
-export async function prepareToRender<CardT extends Constructable>(card: CardT, format: Format): Promise<{ component: ComponentLike<{ Args: never, Blocks: never }> }> {
+export interface RenderOptions { 
+  dataIsDeserialized?: boolean
+}
+
+export async function prepareToRender<CardT extends Constructable>(card: CardT, format: Format, opts?: RenderOptions): Promise<{ component: ComponentLike<{ Args: never, Blocks: never }> }> {
+  let { dataIsDeserialized }: Required<RenderOptions> = { dataIsDeserialized: false, ...opts };
   let model = new card();
   let data = getInitialData(card);
   if (data) {
-    for (let [fieldName, value] of Object.entries(data)) {
-      // we assume that static Card.data property is serialized data
-      serializedSet(model, fieldName, value);
+    if (dataIsDeserialized) {
+      Object.assign(model, data);
+    } else {
+      for (let [fieldName, value] of Object.entries(data)) {
+        serializedSet(model, fieldName, value);
+      }
     }
   }
   let component = getComponent(card, format, model);

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -2,6 +2,9 @@ import GlimmerComponent from '@glimmer/component';
 import { ComponentLike } from '@glint/template';
 
 export const primitive = Symbol('cardstack-primitive');
+export const serialize = Symbol('cardstack-serialize');
+export const deserialize = Symbol('cardstack-deserialize');
+
 const isField = Symbol('cardstack-field');
 
 type CardInstanceType<T extends Constructable> = T extends { [primitive]: infer P } ? P : InstanceType<T>;
@@ -12,35 +15,111 @@ type FieldsTypeFor<CardT extends Constructable> = {
 
 export type Format = 'isolated' | 'embedded' | 'edit';
 
+const deserializedData = new WeakMap<object, Map<string, any>>();
+const serializedData = new WeakMap<object, Map<string, any>>();
+
+function getOrCreateDataBuckets<CardT extends Constructable>(instance: InstanceType<CardT>): { serialized: Map<string, any>, deserialized: Map<string, any> } {
+  let serialized = serializedData.get(instance);
+  if (!serialized) {
+    serialized = new Map();
+    serializedData.set(instance, serialized);
+  }
+  let deserialized = deserializedData.get(instance);
+  if (!deserialized) {
+    deserialized = new Map();
+    deserializedData.set(instance, deserialized);
+  }
+  return { serialized, deserialized };
+}
+
+export function serializedGet<CardT extends Constructable>(model: InstanceType<CardT>, fieldName: string ) {
+  let { serialized, deserialized } = getOrCreateDataBuckets(model);
+  let field = getField(model.constructor, fieldName);
+  let value = serialized.get(fieldName); 
+  if (value !== undefined) {
+    return value;
+  }
+  value = deserialized.get(fieldName);
+  if (typeof (field as any)[serialize] === 'function') {
+    value = (field as any)[serialize](value);
+  }
+  serialized.set(fieldName, value);
+  return value;
+}
+
+export function serializedSet<CardT extends Constructable>(model: InstanceType<CardT>, fieldName: string, value: any ) {
+  let { serialized, deserialized } = getOrCreateDataBuckets(model);
+  let field = getField(model.constructor, fieldName);
+  if (!field) {
+    throw new Error(`Field ${fieldName} does not exist on ${model.constructor.name}`);
+  }
+
+  if (primitive in field) {
+    serialized.set(fieldName, value);
+  } else {
+    let instance = new field();
+    Object.assign(instance, value);
+    serialized.set(fieldName, instance);
+  }
+  deserialized.delete(fieldName);
+}
+
 export function contains<CardT extends Constructable>(card: CardT): CardInstanceType<CardT> {
   if (primitive in card) {
     return {
-      setupField() {
-        let bucket = new WeakMap();
+      setupField(_instance: InstanceType<CardT>, fieldName: string) {
         let get = function(this: InstanceType<CardT>) { 
-          return bucket.get(this); 
+          let { serialized, deserialized } = getOrCreateDataBuckets(this);
+          let value = deserialized.get(fieldName); 
+          let field = getField(this.constructor, fieldName);
+          if (value !== undefined) {
+            return value;
+          }
+          value = serialized.get(fieldName);
+          if (typeof (field as any)[deserialize] === 'function') {
+            value = (field as any)[deserialize](value);
+          }
+          deserialized.set(fieldName, value);
+          return value;
         };
         (get as any)[isField] = card;
         return {
           enumerable: true,
           get,
           set(value: any) {
-            bucket.set(this, value);
+            let { serialized, deserialized } = getOrCreateDataBuckets(this);
+            deserialized.set(fieldName, value);
+            serialized.delete(fieldName);
           }
         };
       }
     } as any;
   } else {
     return {
-      setupField() {
+      setupField(_instance: InstanceType<CardT>, fieldName: string) {
         let instance = new card();
-        let get = function(this: InstanceType<CardT>) { return instance };
+        let get = function(this: InstanceType<CardT>) {
+          let { serialized, deserialized } = getOrCreateDataBuckets(this);
+          let value = deserialized.get(fieldName); 
+          if (value !== undefined) {
+            return value;
+          }
+          value = serialized.get(fieldName);
+          if (value === undefined) {
+            value = instance;
+            serialized.set(fieldName, value);
+          }
+          return value;
+        };
         (get as any)[isField] = card;
         return {
           enumerable: true,
           get,
           set(value: any) {
             Object.assign(instance, value);
+            let { serialized, deserialized } = getOrCreateDataBuckets(this);
+            deserialized.set(fieldName, instance);
+            serialized.delete(fieldName);
           }
         };
       }
@@ -50,8 +129,8 @@ export function contains<CardT extends Constructable>(card: CardT): CardInstance
 
 // our decorators are implemented by Babel, not TypeScript, so they have a
 // different signature than Typescript thinks they do.
-export const field = function(_target: object, _key: string| symbol, { initializer }: { initializer(): any }) {
-  return initializer().setupField();
+export const field = function(target: object, key: string | symbol, { initializer }: { initializer(): any }) {
+  return initializer().setupField(target, key);
 } as unknown as PropertyDecorator;
 
 export type Constructable = new(...args: any) => any;
@@ -116,7 +195,10 @@ export async function prepareToRender<CardT extends Constructable>(card: CardT, 
   let model = new card();
   let data = getInitialData(card);
   if (data) {
-    Object.assign(model, data);
+    for (let [fieldName, value] of Object.entries(data)) {
+      // we assume that static Card.data property is serialized data
+      serializedSet(model, fieldName, value);
+    }
   }
   let component = getComponent(card, format, model);
   return { component };

--- a/host/app/lib/date.gts
+++ b/host/app/lib/date.gts
@@ -1,0 +1,32 @@
+import { Component, primitive, serialize, deserialize } from 'runtime-spike/lib/card-api';
+import { parse, format } from 'date-fns';
+
+// The Intl API is supported in all modern browsers. In older ones, we polyfill
+// it in the application route at app startup.
+const Format = new Intl.DateTimeFormat('us-EN', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+
+export default class DateCard {
+  static [primitive]: Date;
+  static [serialize](date: string | Date) {
+    if (typeof date === 'string') {
+      return date;
+    }
+    return format(date, 'yyyy-MM-dd');
+  }
+  static [deserialize](date: string | Date) {
+    if (date instanceof Date) {
+      return date;
+    }
+    return parse(date, 'yyyy-MM-dd', new Date());
+  }
+  static embedded = class Embedded extends Component<typeof this> {
+    <template><span data-test="date">{{this.formatted}}</span></template>
+    get formatted() {
+      return this.args.model ? Format.format(this.args.model) : undefined
+    }
+  }
+}

--- a/host/package.json
+++ b/host/package.json
@@ -103,6 +103,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-qunit": "^7.2.0",
+    "fast-json-stable-stringify": "^2.1.0",
     "glint-environment-ember-template-imports": "^0.0.2",
     "ignore": "^5.2.0",
     "loader.js": "^4.7.0",

--- a/host/package.json
+++ b/host/package.json
@@ -68,6 +68,7 @@
     "@typescript-eslint/parser": "^5.17.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
+    "date-fns": "^2.28.0",
     "ember-auto-import": "^2.4.0",
     "ember-cli": "~4.2.0",
     "ember-cli-app-version": "^5.0.0",

--- a/host/tests/helpers/render-component.ts
+++ b/host/tests/helpers/render-component.ts
@@ -5,6 +5,7 @@ import {
   Format,
   prepareToRender,
   Constructable,
+  RenderOptions,
 } from 'runtime-spike/lib/card-api';
 import { ComponentLike } from '@glint/template';
 
@@ -14,8 +15,9 @@ export async function renderComponent(C: ComponentLike) {
 
 export async function renderCard(
   card: Constructable,
-  format: Format
+  format: Format,
+  opts?: RenderOptions
 ): Promise<void> {
-  let { component } = await prepareToRender(card, format);
+  let { component } = await prepareToRender(card, format, opts);
   await renderComponent(component);
 }

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -120,15 +120,6 @@ module('Integration | card-basics', function (hooks) {
   });
 
   test('render default templates', async function (assert) {
-    function testString(label: string) {
-      return class TestString {
-        static [primitive]: string;
-        static embedded = class Embedded extends Component<typeof this> {
-          <template><em data-test={{label}}>{{@model}}</em></template>
-        }
-      }
-    }
-
     class Person {
       @field firstName = contains(testString('first-name'));
 
@@ -152,4 +143,33 @@ module('Integration | card-basics', function (hooks) {
     assert.dom('[data-test="title"]').containsText('First Post');
 
   });
+
+  test('can adopt a card', async function (assert) {
+    class Animal {
+      @field species = contains(testString('species'));
+    }
+    class Person extends Animal {
+      @field firstName = contains(testString('first-name'));
+      static embedded = class Embedded extends Component<typeof this> {
+        <template><@fields.firstName /><@fields.species/></template>
+      }
+    }
+
+    class Hassan extends Person {
+      static data = { firstName: 'Hassan', species: 'Homo Sapiens' }
+    }
+
+    await renderCard(Hassan, 'embedded');
+    assert.dom('[data-test="first-name"]').containsText('Hassan');
+    assert.dom('[data-test="species"]').containsText('Homo Sapiens');
+  });
 });
+
+function testString(label: string) {
+  return class TestString {
+    static [primitive]: string;
+    static embedded = class Embedded extends Component<typeof this> {
+      <template><em data-test={{label}}>{{@model}}</em></template>
+    }
+  }
+}

--- a/host/tests/integration/components/serialization-test.gts
+++ b/host/tests/integration/components/serialization-test.gts
@@ -1,9 +1,14 @@
 import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
+import { parse } from 'date-fns';
 import { renderCard } from '../../helpers/render-component';
-import { contains, field, Component } from 'runtime-spike/lib/card-api';
+import { contains, field, Component, serializedGet } from 'runtime-spike/lib/card-api';
 import StringCard from 'runtime-spike/lib/string';
 import DateCard from 'runtime-spike/lib/date';
+
+function p(dateString: string): Date {
+  return parse(dateString, 'yyyy-MM-dd', new Date());
+}
 
 module('Integration | serialization', function (hooks) {
   setupRenderingTest(hooks);
@@ -27,8 +32,22 @@ module('Integration | serialization', function (hooks) {
     assert.dom('[data-test="date"]').containsText('Apr 22, 2022');
   });
 
-  skip('can serialize field');
-  // use @model.field to prove field is serialized
+  test('can serialize field', async function(assert) {
+    class Post {
+      @field title = contains(StringCard)
+      @field created = contains(DateCard)
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>created {{serializedGet @model 'created'}}</template>
+      }
+    }
+    class FirstPost extends Post {
+      // initialze card data as deserialized to force us to serialize instead of using cached data
+      static data = { title: 'First Post', created: p('2022-04-22') }
+    }
+
+    await renderCard(FirstPost, 'isolated', { dataIsDeserialized: true });
+    assert.strictEqual(this.element.textContent!.trim(), 'created 2022-04-22');
+  });
 
   skip('can deserialize a nested field');
   skip('can serialize a nested field');

--- a/host/tests/integration/components/serialization-test.gts
+++ b/host/tests/integration/components/serialization-test.gts
@@ -1,0 +1,42 @@
+import { module, test, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { renderCard } from '../../helpers/render-component';
+import { contains, field, Component } from 'runtime-spike/lib/card-api';
+import StringCard from 'runtime-spike/lib/string';
+import DateCard from 'runtime-spike/lib/date';
+
+module('Integration | serialization', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('can deserialize field', async function (assert) {
+    class Post {
+      @field title = contains(StringCard)
+      @field created = contains(DateCard)
+      static isolated = class Isolated extends Component<typeof this> {
+        <template><@fields.title/> created <@fields.created/></template>
+      }
+    }
+    class FirstPost extends Post {
+      static data = { title: 'First Post', created: '2022-04-22' }
+    }
+
+    await renderCard(FirstPost, 'isolated');
+
+    // the template value 'Apr 22, 2022' can only be realized when the card has
+    // correctly deserialized it's static data property
+    assert.dom('[data-test="date"]').containsText('Apr 22, 2022');
+  });
+
+  skip('can serialize field');
+  // use @model.field to prove field is serialized
+
+  skip('can deserialize a nested field');
+  skip('can serialize a nested field');
+
+  skip('can deserialize a composite field');
+  skip('can serialize a composite field');
+
+  skip('can deserialize a containsMany field');
+  skip('can serialize a containsMany field');
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6912,7 +6912,7 @@ fast-glob@^3.0.3, fast-glob@^3.2.11, fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==


### PR DESCRIPTION
This is in pretty good shape, but I'd like to flesh out all the skipped tests before merging. This leverages the same approach for serialization as we do for card schema instances created from the compiler where we have 2 data buckets: a serialized data bucket and a deserialized data bucket. When you ask for deserialized data we'll check to see if we already have it in the deserialized data bucket and return it if so. Otherwise we'll run a deserializer against the data that we have in the serialized bucket. And vice versa for getting serialized data. When deserialized or serialized data is set, we'll clear the cache for the opposed form of the data. In order to take such an approach, I needed to move the WeakMap for the data into the module scope in order to allow a `serializedGet` and a `serializedSet` (also living in the module scope) to have access to the data. it didn't look like there was an obvious place to put the `serializedSet` and `serializeGet` on the model, so that's why it lives in the module scope.