### PR TITLE
allow arrays to be rerendered

### DIFF
--- a/host/app/components/contains-many.gts
+++ b/host/app/components/contains-many.gts
@@ -46,12 +46,12 @@ export default class ContainsManyEditor extends Component<Signature> {
   }
 
   @action add() {
-    (this.args.model.value as any)[this.safeFieldName] = [...this.args.arrayField.children.map(b => b.value), null];
+    // TODO probably each field card should have the ability to say what a new item should be
+    (this.args.model.value as any)[this.safeFieldName].push(null);
   }
 
   @action remove(index: number) {
-    let value = this.args.arrayField.children.map(b => b.value);
-    value.splice(index, 1);
-    (this.args.model.value as any)[this.safeFieldName] = [ ...value];
+    let items = (this.args.model.value as any)[this.safeFieldName];
+    items.splice(index, 1);
   }
 }

--- a/host/app/components/contains-many.gts
+++ b/host/app/components/contains-many.gts
@@ -51,7 +51,6 @@ export default class ContainsManyEditor extends Component<Signature> {
   }
 
   @action remove(index: number) {
-    let items = (this.args.model.value as any)[this.safeFieldName];
-    items.splice(index, 1);
+    (this.args.model.value as any)[this.safeFieldName].splice(index, 1);
   }
 }

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -604,10 +604,9 @@ export class Box<T> {
 
   get value(): T {
     if (this.fieldName != null) {
-      // I think we might have a consumption issue when we are rendering specific items of a contains-many
-      // it does not seem like we are rerendering specific primitive items when they are changed--perhaps because we are
-      // not consuming them at an item level? currently consumption happens at the whole field.
-      this.containingBox?.value // consume the containing box
+      // consume the containing box so we can trigger rerenders for
+      // individual items in a watched array
+      this.containingBox?.value
       
       return this.model[this.fieldName];
     } else {
@@ -624,14 +623,12 @@ export class Box<T> {
 
   set = (value: T): void => {
     let fieldBox = this.containingBox;
-    let cardBox = fieldBox?.containingBox;
-    if (cardBox && fieldBox && Array.isArray(fieldBox.value)) {
+    if (fieldBox && Array.isArray(fieldBox.value)) {
       let index = this.fieldName;
       if (typeof index !== 'number') {
         throw new Error(`Cannot set a value on an array item with non-numeric index '${String(index)}'`);
       }
       fieldBox.value[index] = value;
-      cardBox.value[fieldBox.fieldName!] = [...fieldBox.value];
     } else {
       this.value = value;
     }

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -661,15 +661,13 @@ export class Box<T> {
         newChildren = value.map((_, index) => new Box(value, index, this));
       } else {
         newChildren = value.map((element, index) => {
-          let found = prevChildren.find((oldBox, i) =>
-            (
-              this.useIndexBasedKeys ? index === i : oldBox.value === element)
-            );
+          let found = prevChildren.find((oldBox, i) => (this.useIndexBasedKeys ? index === i : oldBox.value === element));
           if (found) {
             if (this.useIndexBasedKeys) {
-              // note that the underlying box already has the correct value--also, we are currently
-              // inside a rerender. mutating a watched array in a rerender will spawn
-              // another rerender--and infinitely recurse
+              // note that the underlying box already has the correct value so there
+              // is nothing to do in this case. also, we are currently inside a rerender.
+              // mutating a watched array in a rerender will spawn another rerender which
+              // infinitely recurses.
             } else {
               prevChildren.splice(prevChildren.indexOf(found), 1);
               found.fieldName = index;

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -649,7 +649,7 @@ export class Box<T> {
     if (!Array.isArray(this.value)) {
       throw new Error(`tried to call children() on Boxed non-array value ${this.value} for ${String(this.fieldName)}`);
     }
-    let value = this.value; // Help TS understand that value is an array in closures
+    let value = this.value;
     if (this.prevChildren) {
       let { prevChildren } = this;
       let newChildren: Box<ElementType<T>>[] = value.map((element, index) => {

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -656,8 +656,7 @@ export class Box<T> {
       let { prevChildren } = this;
       let newChildren: Box<ElementType<T>>[];
       if (prevChildren.length > 0 && prevChildren[0].model !== value) {
-        // a new array has been assigned to the field, so let's
-        // make that new array our model instead
+        // a new array has been assigned to the field, so let's make that new array our model instead
         newChildren = value.map((_, index) => new Box(value, index, this));
       } else {
         newChildren = value.map((element, index) => {

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -646,11 +646,10 @@ export class Box<T> {
   private prevChildren: undefined | Box<ElementType<T>>[];
 
   get children(): Box<ElementType<T>>[] {
-    let _value = this.value as T | T[];
-    if (!Array.isArray(_value)) {
+    if (!Array.isArray(this.value)) {
       throw new Error(`tried to call children() on Boxed non-array value ${this.value} for ${String(this.fieldName)}`);
     }
-    let value = _value; // Help TS understand that value is an array in closures
+    let value = this.value; // Help TS understand that value is an array in closures
     if (this.prevChildren) {
       let { prevChildren } = this;
       let newChildren: Box<ElementType<T>>[] = value.map((element, index) => {

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -655,7 +655,7 @@ export class Box<T> {
     if (this.prevChildren) {
       let { prevChildren } = this;
       let newChildren: Box<ElementType<T>>[];
-      if (prevChildren.length > 1 && prevChildren[0].model !== value) {
+      if (prevChildren.length > 0 && prevChildren[0].model !== value) {
         // a new array has been assigned to the field, so let's
         // make that new array our model instead
         newChildren = value.map((_, index) => new Box(value, index, this));

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -607,7 +607,7 @@ export class Box<T> {
       // I think we might have a consumption issue when we are rendering specific items of a contains-many
       // it does not seem like we are rerendering specific primitive items when they are changed--perhaps because we are
       // not consuming them at an item level? currently consumption happens at the whole field.
-      if (this.containingBox.value != null) { 
+      if (this.containingBox?.value != null) { 
         cardTracking.get(this.containingBox.value);
       }
       

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -328,7 +328,7 @@ export const field = function(_target: CardConstructor, key: string | symbol, { 
   return initializer().setupField(key);
 } as unknown as PropertyDecorator;
 
-type SignatureFor<CardT extends CardConstructor> = { Args: { model: CardInstanceType<CardT>; fields: FieldsTypeFor<InstanceType<CardT>>; set: Setter; } }
+export type SignatureFor<CardT extends CardConstructor> = { Args: { model: CardInstanceType<CardT>; fields: FieldsTypeFor<InstanceType<CardT>>; set: Setter; } }
 
 export class Component<CardT extends CardConstructor> extends GlimmerComponent<SignatureFor<CardT>> {
 

--- a/host/app/lib/card-api.gts
+++ b/host/app/lib/card-api.gts
@@ -646,10 +646,11 @@ export class Box<T> {
   private prevChildren: undefined | Box<ElementType<T>>[];
 
   get children(): Box<ElementType<T>>[] {
-    let value = this.value;
-    if (!Array.isArray(value)) {
+    let _value = this.value as T | T[];
+    if (!Array.isArray(_value)) {
       throw new Error(`tried to call children() on Boxed non-array value ${this.value} for ${String(this.fieldName)}`);
     }
+    let value = _value; // Help TS understand that value is an array in closures
     if (this.prevChildren) {
       let { prevChildren } = this;
       let newChildren: Box<ElementType<T>>[] = value.map((element, index) => {
@@ -665,7 +666,10 @@ export class Box<T> {
       this.prevChildren = newChildren;
       return newChildren;
     } else {
-      this.prevChildren = value.map((_element, index) => new Box(value, index, this));
+      // we need to be careful here in that value is live bound and we don't
+      // want the prevChildren changing out from underneath us when the model
+      // is mutated, so we make a new array to hold these values
+      this.prevChildren = value.map((_element, index) => new Box([...value], index, this));
       return this.prevChildren;
     }
   }

--- a/host/app/lib/date.gts
+++ b/host/app/lib/date.gts
@@ -50,8 +50,7 @@ export default class DateCard extends Card {
       if (!this.args.model) {
         return;
       }
-      let deserialized = DateCard.fromSerialized(this.args.model);
-      return DateCard[serialize](deserialized);
+      return DateCard[serialize](this.args.model);
     }
   }
 }

--- a/host/app/lib/datetime.gts
+++ b/host/app/lib/datetime.gts
@@ -53,8 +53,7 @@ export default class DatetimeCard extends Card {
       if (!this.args.model) {
         return;
       }
-      let deserialized = DatetimeCard.fromSerialized(this.args.model);
-      return DatetimeCard[serialize](deserialized).split('.')[0];
+      return DatetimeCard[serialize](this.args.model).split('.')[0];
     }
   }
 }

--- a/host/app/lib/integer.gts
+++ b/host/app/lib/integer.gts
@@ -1,10 +1,11 @@
-import { primitive, Component, Card } from 'runtime-spike/lib/card-api';
+import { primitive, Component, Card, useIndexBasedKey } from 'runtime-spike/lib/card-api';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
 import { pick } from './pick';
 
 export default class IntegerCard extends Card {
   static [primitive]: number;
+  static [useIndexBasedKey];
 
   static embedded = class Embedded extends Component<typeof this> {
     <template>{{@model}}</template>

--- a/host/app/lib/integer.gts
+++ b/host/app/lib/integer.gts
@@ -5,7 +5,7 @@ import { pick } from './pick';
 
 export default class IntegerCard extends Card {
   static [primitive]: number;
-  static [useIndexBasedKey];
+  static [useIndexBasedKey]: never;
 
   static embedded = class Embedded extends Component<typeof this> {
     <template>{{@model}}</template>

--- a/host/app/lib/string.gts
+++ b/host/app/lib/string.gts
@@ -4,7 +4,7 @@ import { pick } from './pick';
 
 export default class StringCard extends Card {
   static [primitive]: string;
-  static [useIndexBasedKey];
+  static [useIndexBasedKey]: never;
   static embedded = class Embedded extends Component<typeof this> {
     <template>{{@model}}</template>
   }

--- a/host/app/lib/string.gts
+++ b/host/app/lib/string.gts
@@ -1,9 +1,10 @@
-import { primitive, Component, Card } from 'runtime-spike/lib/card-api';
+import { primitive, Component, Card, useIndexBasedKey } from 'runtime-spike/lib/card-api';
 import { on } from '@ember/modifier';
 import { pick } from './pick';
 
 export default class StringCard extends Card {
   static [primitive]: string;
+  static [useIndexBasedKey];
   static embedded = class Embedded extends Component<typeof this> {
     <template>{{@model}}</template>
   }

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -462,13 +462,15 @@ module('Integration | card-basics', function (hooks) {
     }
 
     let card = new Person({
-      languagesSpoken: ['english'],
+      languagesSpoken: ['english', "japanese"],
     });
 
     await renderCard(card, 'edit');
-    assert.dom('[data-counter]').hasAttribute('data-counter', '0');
-    await fillIn('[data-counter]', 'italian');
-    assert.dom('[data-counter]').hasAttribute('data-counter', '0');
+    assert.dom('[data-test-item="0"] [data-counter]').hasAttribute('data-counter', '0');
+    assert.dom('[data-test-item="1"] [data-counter]').hasAttribute('data-counter', '1');
+    await fillIn('[data-test-item="0"] [data-counter]', 'italian');
+    assert.dom('[data-test-item="0"] [data-counter]').hasAttribute('data-counter', '0');
+    assert.dom('[data-test-item="1"] [data-counter]').hasAttribute('data-counter', '1');
   });
 
   test('add, remove and edit items in containsMany string field', async function (assert) {

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -478,7 +478,6 @@ module('Integration | card-basics', function (hooks) {
     });
 
     await renderCard(card, 'edit');
-    await this.pauseTest();
     assert.dom('[data-test-item]').exists({ count: 2 });
     assert.dom('[data-test-item="0"] input').hasValue('english');
     assert.dom('[data-test-output]').hasText('english japanese');

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -291,7 +291,7 @@ module('Integration | card-basics', function (hooks) {
     await waitUntil(() => cleanWhiteSpace(this.element.textContent!) === 'Van Gogh Mango Peachy');
   });
 
-  skip('rerender when a containsMany field is mutated via assignment', async function(assert) {
+  test('rerender when a containsMany field is mutated via assignment', async function(assert) {
     class Person extends Card {
       @field pets = containsMany(StringCard);
       static embedded = class Embedded extends Component<typeof this> {
@@ -460,7 +460,7 @@ module('Integration | card-basics', function (hooks) {
     assert.dom('[data-test-output]').hasText('italian french spanish');
   });
 
-  skip('add, remove and edit items in containsMany date and datetime fields', async function (assert) {
+  test('add, remove and edit items in containsMany date and datetime fields', async function (assert) {
     function toDateString(date: Date | null) {
       return date instanceof Date ? date.toISOString().split('T')[0] : null;
     }

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { fillIn, click, waitUntil } from '@ember/test-helpers';
 import { renderCard } from '../../helpers/render-component';
@@ -309,6 +309,9 @@ module('Integration | card-basics', function (hooks) {
   });
 
 
+  skip('rerender when a containsMany field changes size');
+  // both growing and shrinking
+
   test('supports an empty containsMany composite field', async function (assert) {
     class Person extends Card {
       @field firstName = contains(StringCard);
@@ -475,6 +478,7 @@ module('Integration | card-basics', function (hooks) {
     });
 
     await renderCard(card, 'edit');
+    await this.pauseTest();
     assert.dom('[data-test-item]').exists({ count: 2 });
     assert.dom('[data-test-item="0"] input').hasValue('english');
     assert.dom('[data-test-output]').hasText('english japanese');

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -309,8 +309,21 @@ module('Integration | card-basics', function (hooks) {
   });
 
 
-  skip('rerender when a containsMany field changes size');
-  // both growing and shrinking
+  test('rerender when a containsMany field changes size', async function(assert) {
+    class Person extends Card {
+      @field pets = containsMany(StringCard);
+      static embedded = class Embedded extends Component<typeof this> {
+        <template><@fields.pets/></template>
+      }
+    }
+    let person = new Person({ pets: ['Mango', 'Van Gogh'] });
+    await renderCard(person, 'embedded');
+    assert.strictEqual(cleanWhiteSpace(this.element.textContent!), 'Mango Van Gogh');
+    person.pets.push('Peachy');
+    await waitUntil(() => cleanWhiteSpace(this.element.textContent!) === 'Mango Van Gogh Peachy');
+    person.pets.shift();
+    await waitUntil(() => cleanWhiteSpace(this.element.textContent!) === 'Van Gogh Peachy');
+  });
 
   test('supports an empty containsMany composite field', async function (assert) {
     class Person extends Card {

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -1,4 +1,4 @@
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { fillIn, click, waitUntil } from '@ember/test-helpers';
 import { renderCard } from '../../helpers/render-component';


### PR DESCRIPTION
This fixes the issue where our Boxes were not calculating stable array contents because the model was changing out from underneath our cached box field values