### PR TITLE
Make file tree rendering more stable

### DIFF
--- a/host/app/components/file-tree.gts
+++ b/host/app/components/file-tree.gts
@@ -18,7 +18,7 @@ export default class FileTree extends Component<Args> {
   <template>
     {{#if @localRealm.isAvailable}}
       <button {{on "click" this.closeRealm}}>Close local realm</button>
-      {{#each this.listing.entries as |entry|}}
+      {{#each this.listing.entries key="path" as |entry|}}
         {{#if (eq entry.handle.kind 'file')}}
           <div class="item file {{if (eq entry.name this.args.file) 'selected'}} indent-{{entry.indent}}"
             {{on "click" (fn this.open entry)}}>

--- a/host/app/resources/directory.ts
+++ b/host/app/resources/directory.ts
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { registerDestructor } from '@ember/destroyable';
 import ignore from 'ignore';
 import { readFileAsText } from '@cardstack/worker/src/util';
+import isEqual from 'lodash/isEqual';
 
 interface Args {
   named: { dir: FileSystemDirectoryHandle | null };
@@ -67,7 +68,16 @@ export class DirectoryResource extends Resource<Args> {
   private async readdir() {
     if (this.dir) {
       let ignoreFile = await getIgnorePatterns(this.dir);
-      this.entries = await getDirectoryEntries(this.dir, [], ignoreFile);
+      let entries = await getDirectoryEntries(this.dir, [], ignoreFile);
+      if (
+        entries.length !== this.entries.length ||
+        !isEqual(
+          entries.map((e) => e.path),
+          this.entries.map((e) => e.path)
+        )
+      ) {
+        this.entries = entries;
+      }
     } else {
       this.entries = [];
     }

--- a/host/app/resources/directory.ts
+++ b/host/app/resources/directory.ts
@@ -3,7 +3,6 @@ import { tracked } from '@glimmer/tracking';
 import { registerDestructor } from '@ember/destroyable';
 import ignore from 'ignore';
 import { readFileAsText } from '@cardstack/worker/src/util';
-import isEqual from 'lodash/isEqual';
 
 interface Args {
   named: { dir: FileSystemDirectoryHandle | null };
@@ -68,16 +67,7 @@ export class DirectoryResource extends Resource<Args> {
   private async readdir() {
     if (this.dir) {
       let ignoreFile = await getIgnorePatterns(this.dir);
-      let entries = await getDirectoryEntries(this.dir, [], ignoreFile);
-      if (
-        entries.length !== this.entries.length ||
-        !isEqual(
-          entries.map((e) => e.path),
-          this.entries.map((e) => e.path)
-        )
-      ) {
-        this.entries = entries;
-      }
+      this.entries = await getDirectoryEntries(this.dir, [], ignoreFile);
     } else {
       this.entries = [];
     }


### PR DESCRIPTION
The file tree was constantly being re-rendered in the DOM, potentially causing some of the mouse clicks to fall through. Added a small optimization so it's only re-rendered as changes happen to file content or to the file tree. I couldn't replicate the bug too well, so will need another person to double check that this works.