### PR TITLE
Support for the /sources API

### DIFF
--- a/cards/Post/1.json
+++ b/cards/Post/1.json
@@ -11,7 +11,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/post.gts",
+        "module": "http://local-realm/cards/post.gts",
         "name": "Post"
       }
     }

--- a/host/app/components/go.gts
+++ b/host/app/components/go.gts
@@ -17,11 +17,10 @@ import {
   languageConfigs
 } from '../utils/editor-language';
 import { externalsMap } from '@cardstack/runtime-common';
-import type { FileResource } from '../resources/file';
 
 interface Signature {
   Args: {
-    openFile: FileResource | undefined;
+    source: string | undefined;
     path: string | undefined
   }
 }

--- a/host/app/components/go.gts
+++ b/host/app/components/go.gts
@@ -41,10 +41,10 @@ export default class Go extends Component<Signature> {
                       contentChanged=this.contentChanged}}></div>
         <div class="preview">
           {{#if (isRunnable this.openFile.name)}}
-            <ImportModule @url={{localRealmURL this.openFile.path}}>
+            <ImportModule @url={{localRealmCardsURL this.openFile.path}}>
               <:ready as |module|>
                 <SchemaInspector
-                  @path={{localRealmURL this.openFile.path}}
+                  @sourceURL={{localRealmSourcesURL this.openFile.path}}
                   @module={{module}}
                   @src={{this.openFile.content}}
                   @inspector={{this.inspector}}
@@ -56,7 +56,7 @@ export default class Go extends Component<Signature> {
               </:error>
             </ImportModule>
           {{else if this.openFileCardJSON}}
-            <ImportModule @url={{relativeFrom this.openFileCardJSON.data.meta.adoptsFrom.module (localRealmURL this.openFile.path)}} >
+            <ImportModule @url={{relativeFrom this.openFileCardJSON.data.meta.adoptsFrom.module (localRealmCardsURL this.openFile.path)}} >
               <:ready as |module|>
                 <CardEditor
                   @module={{module}}
@@ -153,7 +153,12 @@ function isRunnable(filename: string): boolean {
   return ['.gjs', '.js', '.gts', '.ts'].some(extension => filename.endsWith(extension));
 }
 
-function localRealmURL(path: string): string {
+function localRealmCardsURL(path: string): string {
+  return `http://local-realm/cards/${path}`;
+}
+
+// TODO this should be /sources/* 
+function localRealmSourcesURL(path: string): string {
   return `http://local-realm/${path}`;
 }
 

--- a/host/app/routes/application.ts
+++ b/host/app/routes/application.ts
@@ -1,14 +1,11 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import { file, FileResource } from '../resources/file';
-import LocalRealm from '../services/local-realm';
 import type RouterService from '@ember/routing/router-service';
-
-const executableExtensions = ['.js', '.gjs', '.ts', '.gts'];
 
 export default class Application extends Route<{
   path: string | undefined;
-  openFile: FileResource | undefined;
+  source: string | undefined;
+  url: string | undefined;
 }> {
   queryParams = {
     path: {
@@ -16,44 +13,44 @@ export default class Application extends Route<{
     },
   };
 
-  @service declare localRealm: LocalRealm;
   @service declare router: RouterService;
 
   async model(args: { path: string | undefined }) {
     let { path } = args;
-    await this.localRealm.startedUp;
-
-    if (this.localRealm.isEmpty) {
-      return { path: undefined, openFile: undefined };
+    if (!path) {
+      return { path: undefined, source: undefined, url: undefined };
     }
 
-    if (!this.localRealm.isAvailable) {
-      throw new Error(`unable to start local realm`);
+    let url = `http://local-realm/sources/${path}`;
+    let response = await fetch(url);
+    if (!response.ok) {
+      // TODO should we have an error route?
+      console.error(
+        `Could not load ${url}: ${response.status}, ${response.statusText}`
+      );
+      return { path, source: undefined, url: response.url };
     }
 
-    let openFile: FileResource | undefined;
-    if (path) {
-      let attemptedPaths = path.split('/').pop()?.includes('.')
-        ? [path]
-        : [path, ...executableExtensions.map((e) => path + e)];
-      for (let attemptedPath of attemptedPaths) {
-        openFile = file(
-          this,
-          () => attemptedPath,
-          () =>
-            this.localRealm.isAvailable ? this.localRealm.fsHandle : undefined
-        );
-        await openFile.loading;
-        if (openFile.state === 'ready') {
-          if (path !== attemptedPath) {
-            this.router.transitionTo({
-              queryParams: { path: attemptedPath },
-            });
-          }
-        }
+    // don't bother loading the source if we're about to redirect
+    let source = url === response.url ? await response.text() : undefined;
+
+    return { path, source, url: response.url };
+
+    // TODO how to we deal with live loading of sources?
+  }
+
+  afterModel(model: {
+    path: string | undefined;
+    source: string | undefined;
+    url: string | undefined;
+  }) {
+    let { path, url } = model;
+    if (url && path) {
+      let requestedUrl = `http://local-realm/sources/${path}`;
+      if (requestedUrl !== url) {
+        let path = new URL(url).pathname.replace(/^\/sources\//, '');
+        this.router.transitionTo('application', { queryParams: { path } });
       }
     }
-
-    return { path, openFile };
   }
 }

--- a/host/app/templates/application.hbs
+++ b/host/app/templates/application.hbs
@@ -1,5 +1,5 @@
 {{page-title 'RuntimeSpike'}}
 
-<Go @path={{this.model.path}} @openFile={{this.model.openFile}} />
+<Go @path={{this.model.path}} @source={{this.model.source}} />
 
 {{outlet}}

--- a/host/tests/integration/components/schema-inspector-test.gts
+++ b/host/tests/integration/components/schema-inspector-test.gts
@@ -35,7 +35,7 @@ module('Integration | schema-inspector', function (hooks) {
             @module={{multipleCardsModule}}
             @src={{multipleCardsSrc}}
             @inspector={{inspector}}
-            @path="/"
+            @sourceURL="http://local-realm/"
           />
         </template>
       }
@@ -53,7 +53,7 @@ module('Integration | schema-inspector', function (hooks) {
             @module={{multipleCardsModule}}
             @src={{multipleCardsSrc}}
             @inspector={{inspector}}
-            @path="/"
+            @sourceURL="http://local-realm/"
           />
         </template>
       }
@@ -71,7 +71,7 @@ module('Integration | schema-inspector', function (hooks) {
             @module={{singleCardModule}}
             @src={{singleCardSrc}}
             @inspector={{inspector}}
-            @path="/"
+            @sourceURL="http://local-realm/"
           />
         </template>
       }
@@ -89,7 +89,7 @@ module('Integration | schema-inspector', function (hooks) {
             @module={{noCardsModule}}
             @src={{noCardsSrc}}
             @inspector={{inspector}}
-            @path="/"
+            @sourceURL="http://local-realm/"
           />
         </template>
       }
@@ -108,7 +108,7 @@ module('Integration | schema-inspector', function (hooks) {
             @module={{singleCardModule}}
             @src={{singleCardSrc}}
             @inspector={{inspector}}
-            @path="/"
+            @sourceURL="http://local-realm/"
           />
         </template>
       }
@@ -127,7 +127,7 @@ module('Integration | schema-inspector', function (hooks) {
             @module={{singleCardModule}}
             @src={{singleCardSrc}}
             @inspector={{inspector}}
-            @path="/"
+            @sourceURL="http://local-realm/"
           />
         </template>
       }
@@ -147,7 +147,7 @@ module('Integration | schema-inspector', function (hooks) {
             @module={{singleCardModule}}
             @src={{singleCardSrc}}
             @inspector={{inspector}}
-            @path="/"
+            @sourceURL="http://local-realm/"
           />
         </template>
       }
@@ -167,7 +167,7 @@ module('Integration | schema-inspector', function (hooks) {
             @module={{usesExternalCardModule}}
             @src={{usesExternalCardSrc}}
             @inspector={{inspector}}
-            @path="/"
+            @sourceURL="http://local-realm/"
           />
         </template>
       }
@@ -184,7 +184,7 @@ module('Integration | schema-inspector', function (hooks) {
             @module={{multipleCardsModule}}
             @src={{multipleCardsSrc}}
             @inspector={{inspector}}
-            @path="/"
+            @sourceURL="http://local-realm/"
           />
         </template>
       }

--- a/worker/src/fetch.ts
+++ b/worker/src/fetch.ts
@@ -52,7 +52,7 @@ export class FetchHandler {
         );
       }
       if (url.origin === 'http://local-realm') {
-        return await this.handleLocalRealm(request, url);
+        return await this.handleLocalRealm(url);
       }
       if (url.origin === 'http://externals') {
         return generateExternalStub(url.pathname.slice(1));
@@ -104,12 +104,18 @@ export class FetchHandler {
       the convention can be to use reexports to manage package versions (that are pinned)
   */
 
-  private async handleLocalRealm(
-    _request: Request,
-    url: URL
-  ): Promise<Response> {
+  private async handleLocalRealm(url: URL): Promise<Response> {
+    if (url.pathname.startsWith('/cards/')) {
+      return await this.handleCards(url.pathname.slice('/cards/'.length));
+    }
+    let handle = await this.getLocalFile(url.pathname.slice(1));
+    // TODO this will eventually be the /sources/ endpoint
+    return await this.serveLocalFile(handle);
+  }
+
+  private async handleCards(path: string): Promise<Response> {
     let handle = await this.getLocalFileWithFallbacks(
-      url.pathname.slice(1),
+      path,
       executableExtensions
     );
     if (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1005,13 +1005,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cspotcode/source-map-support@^0.8.0":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
-  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
-  dependencies:
-    "@jridgewell/trace-mapping" "0.3.9"
-
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
@@ -1661,14 +1654,6 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz#771a1d8d744eeb71b6adb35808e1a6c7b9b8c8ec"
   integrity sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==
 
-"@jridgewell/trace-mapping@0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
-  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.0.3"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-
 "@jridgewell/trace-mapping@^0.3.0":
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz#f6a0832dffd5b8a6aaa633b7d9f8e8e94c83a0c3"
@@ -1724,26 +1709,6 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
-
-"@tsconfig/node10@^1.0.7":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
-  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
-
-"@tsconfig/node12@^1.0.7":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
-  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
-
-"@tsconfig/node14@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
-  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
-
-"@tsconfig/node16@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
-  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
 "@types/acorn@^4.0.3":
   version "4.0.6"
@@ -2166,14 +2131,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
-"@types/node-fetch@^2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
-  integrity sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==
-  dependencies:
-    "@types/node" "*"
-    form-data "^3.0.0"
-
 "@types/node@*", "@types/node@>=10.0.0":
   version "17.0.23"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
@@ -2241,11 +2198,6 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz#4151a81b4052c80bc2becbae09f3a9ec010a9c7a"
   integrity sha512-Lja2xYuuf2B3knEsga8ShbOdsfNOtzT73GyJmZyY7eGl2+ajOqrs8yM5ze0fsSoYwvA6bw7/Qr7OZ7PEEmYwWg==
-
-"@types/tmp@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.3.tgz#908bfb113419fd6a42273674c00994d40902c165"
-  integrity sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -2695,11 +2647,6 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.1.1:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
-  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
-
 acorn@^5.0.0, acorn@^5.5.3:
   version "5.7.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
@@ -2885,11 +2832,6 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
-
-arg@^4.1.0:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
-  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -3301,7 +3243,7 @@ babel-plugin-ember-modules-api-polyfill@^3.5.0:
   dependencies:
     ember-rfc176-data "^0.3.17"
 
-babel-plugin-ember-template-compilation@^1.0.0, babel-plugin-ember-template-compilation@^1.0.2:
+babel-plugin-ember-template-compilation@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-1.0.2.tgz#e0695b8ad5a8fe6b2cbdff1eadb01cf402731ad6"
   integrity sha512-4HBMksmlYsWEf/C/n3uW5rkBRbUp4FNaspzdQTAHgLbfCJnkLze8R6i6sUSge48y/Wne7mx+vcImI1o6rlUwXQ==
@@ -3880,13 +3822,6 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
-
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
-  dependencies:
-    balanced-match "^1.0.0"
 
 braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
@@ -5224,11 +5159,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-require@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
-  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
-
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -5494,11 +5424,6 @@ detect-newline@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
-
-diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diff@^5.0.0:
   version "5.0.0"
@@ -7391,15 +7316,6 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
-  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
 fs-extra@^4.0.2, fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
@@ -7673,17 +7589,6 @@ glob@^7.0.4, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-glob@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
-  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
 
 global-modules@^1.0.0:
   version "1.0.0"
@@ -9202,11 +9107,6 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@^1.1.1:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
-  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
-
 makeerror@1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.12.tgz#3e5dd2079a82e812e983cc6610c4a2cb0eaa801a"
@@ -9445,13 +9345,6 @@ minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
-  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimist@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.1.tgz#827ba4e7593464e7c221e8c5bed930904ee2c455"
@@ -9636,7 +9529,7 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -12252,25 +12145,6 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-node@^10.8.1:
-  version "10.8.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.8.1.tgz#ea2bd3459011b52699d7e88daa55a45a1af4f066"
-  integrity sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==
-  dependencies:
-    "@cspotcode/source-map-support" "^0.8.0"
-    "@tsconfig/node10" "^1.0.7"
-    "@tsconfig/node12" "^1.0.7"
-    "@tsconfig/node14" "^1.0.0"
-    "@tsconfig/node16" "^1.0.2"
-    acorn "^8.4.1"
-    acorn-walk "^8.1.1"
-    arg "^4.1.0"
-    create-require "^1.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    v8-compile-cache-lib "^3.0.1"
-    yn "3.1.1"
-
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -12351,11 +12225,6 @@ typescript@^4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
   integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
-
-typescript@^4.7.3:
-  version "4.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
-  integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -12542,11 +12411,6 @@ uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-v8-compile-cache-lib@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
-  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.3.0:
   version "2.3.0"
@@ -13117,11 +12981,6 @@ yargs@^17.0.1, yargs@^17.3.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
-
-yn@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
-  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
this builds on top of https://github.com/cardstack/runtime-spike/pull/57. Merge that first and then rebase

Very WIP right now since this is the change that will remove file handles and ripples thru the entire host. One thing that I'm not sure about is how we want to retain the live file contents syncing. right now the route loads the file from the /sources API--but it seems bad to have a route triggering model changes outside of a route transition. perhaps this should get extracted into a service?