### PR TITLE
Fixes race condition when opening local realm for the first time

### DIFF
--- a/runtime-common/index.ts
+++ b/runtime-common/index.ts
@@ -31,6 +31,8 @@ export interface DirectoryEntryRelationship {
     kind: "directory" | "file";
   };
 }
+export const protocolRelativeBaseOrigin = "//cardstack.com";
+export const baseOrigin = `http:${protocolRelativeBaseOrigin}`;
 
 export const executableExtensions = [".js", ".gjs", ".ts", ".gts"];
 

--- a/runtime-common/search-index.ts
+++ b/runtime-common/search-index.ts
@@ -1,8 +1,11 @@
-import { Realm, executableExtensions } from ".";
+import {
+  Realm,
+  executableExtensions,
+  baseOrigin,
+  protocolRelativeBaseOrigin,
+} from ".";
 import { ModuleSyntax } from "./module-syntax";
 import { ClassReference, PossibleCardClass } from "./schema-analysis-plugin";
-
-const baseOrigin = "http://cardstack.com";
 
 export type CardRef =
   | {
@@ -427,7 +430,7 @@ function isOurFieldDecorator(ref: ClassReference, inModule: string): boolean {
   return (
     ref.type === "external" &&
     new URL(ref.module, inModule).href ===
-      new URL("//cardstack.com/base/card-api", inModule).href &&
+      new URL(`${protocolRelativeBaseOrigin}/base/card-api`, inModule).href &&
     ref.name === "field"
   );
 }
@@ -439,7 +442,7 @@ function getFieldType(
   if (
     ref.type === "external" &&
     new URL(ref.module, inModule).href ===
-      "http://cardstack.com/base/card-api" &&
+      new URL(`${protocolRelativeBaseOrigin}/base/card-api`, inModule).href &&
     ["contains", "containsMany"].includes(ref.name)
   ) {
     return ref.name as ReturnType<typeof getFieldType>;

--- a/worker/src/fetch.ts
+++ b/worker/src/fetch.ts
@@ -19,7 +19,7 @@ import {
   serveLocalFile,
 } from './file-system';
 import { handle as handleJSONAPI } from './json-api';
-import { executableExtensions } from '@cardstack/runtime-common';
+import { executableExtensions, baseOrigin } from '@cardstack/runtime-common';
 import { SearchIndex } from '@cardstack/runtime-common/search-index';
 import { LocalRealm } from './local-realm';
 
@@ -67,10 +67,7 @@ export class FetchHandler {
 
       let url = new URL(request.url);
 
-      if (
-        url.origin === 'http://cardstack.com' &&
-        url.pathname.startsWith('/base/')
-      ) {
+      if (url.origin === baseOrigin && url.pathname.startsWith('/base/')) {
         return generateExternalStub(
           url.pathname.replace('/base/', 'runtime-spike/lib/')
         );

--- a/worker/src/message-handler.ts
+++ b/worker/src/message-handler.ts
@@ -28,6 +28,9 @@ export class MessageHandler {
       case 'setDirectoryHandle':
         this.fs = data.handle;
         this.finishedStarting();
+        if (this.fs) {
+          send(source, { type: 'setDirectoryHandleAcknowledged' });
+        }
         return;
       default:
         throw assertNever(data);

--- a/worker/src/messages.ts
+++ b/worker/src/messages.ts
@@ -4,6 +4,9 @@
 export interface RequestDirectoryHandle {
   type: 'requestDirectoryHandle';
 }
+export interface SetDirectoryHandleAcknowledged {
+  type: 'setDirectoryHandleAcknowledged';
+}
 
 export interface DirectoryHandleResponse {
   type: 'directoryHandleResponse';
@@ -16,7 +19,9 @@ export interface SetDirectoryHandle {
 }
 
 export type ClientMessage = RequestDirectoryHandle | SetDirectoryHandle;
-export type WorkerMessage = DirectoryHandleResponse;
+export type WorkerMessage =
+  | DirectoryHandleResponse
+  | SetDirectoryHandleAcknowledged;
 export type Message = ClientMessage | WorkerMessage;
 
 function isMessageLike(
@@ -59,6 +64,8 @@ export function isWorkerMessage(message: unknown): message is WorkerMessage {
         ((message as any).handle === null ||
           (message as any).handle instanceof FileSystemDirectoryHandle)
       );
+    case 'setDirectoryHandleAcknowledged':
+      return true;
     default:
       return false;
   }


### PR DESCRIPTION
This PR fixes a race condition when opening a local realm for the first time. What was happening was that the host was sending the local realm to the service worker and then immediately asking the service worker for a directory listing before the service worker had completed setting the local realm internally. I added a new state to the host's local realm service that waits for the service worker to acknowledge the receipt of the local realm before moving into the available state.