### PR TITLE
Implement `eq` filter in search-index query

### DIFF
--- a/host/tests/unit/realm-test.ts
+++ b/host/tests/unit/realm-test.ts
@@ -184,7 +184,11 @@ module('Unit | realm', function () {
       }
 
       let searchIndex = realm.searchIndex;
-      let card = await searchIndex.card(new URL(json.data.links.self));
+      let card = (
+        await searchIndex.search({
+          filter: { eq: { id: json.data.links.self } },
+        })
+      )[0];
       assert.strictEqual(
         card?.id,
         'http://test-realm/Card/1',
@@ -243,7 +247,11 @@ module('Unit | realm', function () {
       }
 
       let searchIndex = realm.searchIndex;
-      let card = await searchIndex.card(new URL(json.data.links.self));
+      let card = (
+        await searchIndex.search({
+          filter: { eq: { id: json.data.links.self } },
+        })
+      )[0];
       assert.strictEqual(
         card?.id,
         'http://test-realm/Card/2',
@@ -360,7 +368,11 @@ module('Unit | realm', function () {
     }
 
     let searchIndex = realm.searchIndex;
-    let card = await searchIndex.card(new URL(json.data.links.self));
+    let card = (
+      await searchIndex.search({
+        filter: { eq: { id: json.data.links.self } },
+      })
+    )[0];
     assert.strictEqual(
       card?.id,
       'http://test-realm/dir/card',
@@ -421,7 +433,11 @@ module('Unit | realm', function () {
     let cards = await searchIndex.search({});
     assert.strictEqual(cards.length, 2, 'two cards found');
 
-    let card = await searchIndex.card(new URL('http://test-realm/cards/2'));
+    let card = (
+      await searchIndex.search({
+        filter: { eq: { id: 'http://test-realm/cards/2' } },
+      })
+    )[0];
     assert.strictEqual(
       card?.id,
       'http://test-realm/cards/2',
@@ -449,10 +465,18 @@ module('Unit | realm', function () {
     );
     assert.strictEqual(response.status, 204, 'status was 204');
 
-    card = await searchIndex.card(new URL('http://test-realm/cards/2'));
+    card = (
+      await searchIndex.search({
+        filter: { eq: { id: 'http://test-realm/cards/2' } },
+      })
+    )[0];
     assert.strictEqual(card, undefined, 'card was deleted');
 
-    card = await searchIndex.card(new URL('http://test-realm/cards/1'));
+    card = (
+      await searchIndex.search({
+        filter: { eq: { id: 'http://test-realm/cards/1' } },
+      })
+    )[0];
     assert.strictEqual(
       card?.id,
       'http://test-realm/cards/1',

--- a/host/tests/unit/realm-test.ts
+++ b/host/tests/unit/realm-test.ts
@@ -184,11 +184,7 @@ module('Unit | realm', function () {
       }
 
       let searchIndex = realm.searchIndex;
-      let card = (
-        await searchIndex.search({
-          filter: { eq: { id: json.data.links.self } },
-        })
-      )[0];
+      let card = (await searchIndex.search({ id: json.data.links.self }))[0];
       assert.strictEqual(
         card?.id,
         'http://test-realm/Card/1',
@@ -247,11 +243,7 @@ module('Unit | realm', function () {
       }
 
       let searchIndex = realm.searchIndex;
-      let card = (
-        await searchIndex.search({
-          filter: { eq: { id: json.data.links.self } },
-        })
-      )[0];
+      let card = (await searchIndex.search({ id: json.data.links.self }))[0];
       assert.strictEqual(
         card?.id,
         'http://test-realm/Card/2',
@@ -368,11 +360,7 @@ module('Unit | realm', function () {
     }
 
     let searchIndex = realm.searchIndex;
-    let card = (
-      await searchIndex.search({
-        filter: { eq: { id: json.data.links.self } },
-      })
-    )[0];
+    let card = (await searchIndex.search({ id: json.data.links.self }))[0];
     assert.strictEqual(
       card?.id,
       'http://test-realm/dir/card',
@@ -434,9 +422,7 @@ module('Unit | realm', function () {
     assert.strictEqual(cards.length, 2, 'two cards found');
 
     let card = (
-      await searchIndex.search({
-        filter: { eq: { id: 'http://test-realm/cards/2' } },
-      })
+      await searchIndex.search({ id: 'http://test-realm/cards/2' })
     )[0];
     assert.strictEqual(
       card?.id,
@@ -465,18 +451,10 @@ module('Unit | realm', function () {
     );
     assert.strictEqual(response.status, 204, 'status was 204');
 
-    card = (
-      await searchIndex.search({
-        filter: { eq: { id: 'http://test-realm/cards/2' } },
-      })
-    )[0];
+    card = (await searchIndex.search({ id: 'http://test-realm/cards/2' }))[0];
     assert.strictEqual(card, undefined, 'card was deleted');
 
-    card = (
-      await searchIndex.search({
-        filter: { eq: { id: 'http://test-realm/cards/1' } },
-      })
-    )[0];
+    card = (await searchIndex.search({ id: 'http://test-realm/cards/1' }))[0];
     assert.strictEqual(
       card?.id,
       'http://test-realm/cards/1',

--- a/host/tests/unit/search-index-test.ts
+++ b/host/tests/unit/search-index-test.ts
@@ -706,19 +706,36 @@ module('Unit | search-index', function () {
       await indexer.run();
     });
 
-    test('can filter cards by id', async function (assert) {
+    test('can search cards by id', async function (assert) {
       let matching = await indexer.search({
-        filter: {
-          eq: {
-            id: 'http://test-realm/card-1',
-          },
-        },
+        id: 'http://test-realm/card-1',
       });
       assert.strictEqual(matching.length, 1, 'found one card');
       assert.strictEqual(
         matching[0]?.id,
         'http://test-realm/card-1',
         'card id is correct'
+      );
+    });
+
+    test('can filter cards by using `eq` on attributes', async function (assert) {
+      let matching = await indexer.search({
+        filter: {
+          eq: {
+            'attributes.name': 'card 1',
+          },
+        },
+      });
+      assert.strictEqual(matching.length, 2, 'found matching cards');
+      assert.strictEqual(
+        matching[0]?.id,
+        'http://test-realm/card-1',
+        'first card id is correct'
+      );
+      assert.strictEqual(
+        matching[1]?.id,
+        'http://test-realm/cards/1',
+        'second card id is correct'
       );
     });
 

--- a/host/tests/unit/search-index-test.ts
+++ b/host/tests/unit/search-index-test.ts
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { TestRealm, TestRealmAdapter } from '../helpers';
 import { RealmPaths } from '@cardstack/runtime-common/paths';
 import { SearchIndex } from '@cardstack/runtime-common/search-index';
@@ -647,11 +647,32 @@ module('Unit | search-index', function () {
 
   module('query', function (hooks) {
     const sampleCards = {
+      'cards.gts': `
+        import { contains, field, Card } from 'https://cardstack.com/base/card-api';
+        import StringCard from 'https://cardstack.com/base/string';
+        import IntegerCard from 'https://cardstack.com/base/integer';
+
+        export class Person extends Card {
+          @field name = contains(StringCard);
+          @field email = contains(StringCard);
+        }
+
+        export class Post extends Card {
+          @field title = contains(StringCard);
+          @field description = contains(StringCard);
+          @field author = contains(Person);
+          @fields views = contains(IntegerCard);
+        }
+      `,
       'card-1.json': {
         data: {
           type: 'card',
           attributes: {
-            name: 'card 1',
+            title: 'Card 1',
+            description: 'Sample post',
+            author: {
+              name: 'Cardy',
+            },
           },
           meta: {
             adoptsFrom: {
@@ -665,13 +686,17 @@ module('Unit | search-index', function () {
         data: {
           type: 'card',
           attributes: {
-            name: 'card 1',
-            description: 'first article',
-            type: 'article',
+            title: 'Card 1',
+            description: 'Sample post',
+            author: {
+              name: 'Carl Stack',
+            },
+            createdAt: new Date(2022, 7, 1),
+            views: 10,
           },
           meta: {
             adoptsFrom: {
-              module: 'https://cardstack.com/base/card-api',
+              module: `${paths.url}/Post`,
               name: 'Card',
             },
           },
@@ -681,16 +706,18 @@ module('Unit | search-index', function () {
         data: {
           type: 'card',
           attributes: {
-            name: 'card 2',
-            type: 'article',
+            title: 'Card 2',
+            description: 'Sample post',
             author: {
-              name: 'carl stack',
+              name: 'Carl Stack',
               email: 'carl@stack.com',
             },
+            createdAt: new Date(2022, 7, 22),
+            views: 5,
           },
           meta: {
             adoptsFrom: {
-              module: 'https://cardstack.com/base/card-api',
+              module: `${paths.url}/Post`,
               name: 'Card',
             },
           },
@@ -711,40 +738,33 @@ module('Unit | search-index', function () {
         id: 'http://test-realm/card-1',
       });
       assert.strictEqual(matching.length, 1, 'found one card');
-      assert.strictEqual(
-        matching[0]?.id,
-        'http://test-realm/card-1',
-        'card id is correct'
-      );
+      assert.strictEqual(matching[0]?.id, 'http://test-realm/card-1');
     });
 
-    test('can filter cards by using `eq` on attributes', async function (assert) {
+    test(`can search for cards by using the 'eq' filter`, async function (assert) {
       let matching = await indexer.search({
         filter: {
           eq: {
-            'attributes.name': 'card 1',
+            'attributes.title': 'Card 1',
+            'attributes.description': 'Sample post',
           },
         },
       });
-      assert.strictEqual(matching.length, 2, 'found matching cards');
-      assert.strictEqual(
-        matching[0]?.id,
-        'http://test-realm/card-1',
-        'first card id is correct'
-      );
-      assert.strictEqual(
-        matching[1]?.id,
-        'http://test-realm/cards/1',
-        'second card id is correct'
-      );
+      assert.strictEqual(matching.length, 2, 'found two cards');
+      assert.strictEqual(matching[0]?.id, 'http://test-realm/card-1');
+      assert.strictEqual(matching[1]?.id, 'http://test-realm/cards/1');
     });
 
-    test('can use `eq` filter on multiple fields', async function (assert) {
+    test('can combine multiple filters', async function (assert) {
       let matching = await indexer.search({
         filter: {
           eq: {
-            'attributes.name': 'card 1',
-            'attributes.type': 'article',
+            'attributes.title': 'Card 1',
+          },
+          not: {
+            eq: {
+              'attributes.author.name': 'Cardy',
+            },
           },
         },
       });
@@ -752,16 +772,49 @@ module('Unit | search-index', function () {
       assert.strictEqual(matching[0]?.id, 'http://test-realm/cards/1');
     });
 
-    test('can filter on a deeply nested field using `eq`', async function (assert) {
+    // Tests from hub/**/**/card-service-test.ts
+    skip('can filter by card type');
+    skip(`can filter on a card's own fields using gt`);
+    skip(`gives a good error when query refers to missing card`);
+    skip(`gives a good error when query refers to missing field`);
+
+    test(`can filter on a nested field using 'eq'`, async function (assert) {
       let matching = await indexer.search({
         filter: {
           eq: {
-            'attributes.author.email': 'carl@stack.com',
+            'attributes.author.name': 'Carl Stack',
           },
         },
       });
-      assert.strictEqual(matching.length, 1);
-      assert.strictEqual(matching[0]?.id, 'http://test-realm/cards/2');
+      assert.strictEqual(matching.length, 2);
+      assert.strictEqual(matching[0]?.id, 'http://test-realm/cards/1');
+      assert.strictEqual(matching[1]?.id, 'http://test-realm/cards/2');
     });
+
+    test('can negate a filter', async function (assert) {
+      let matching = await indexer.search({
+        filter: {
+          not: {
+            eq: {
+              'attributes.author.email': 'carl@stack.com',
+            },
+          },
+        },
+      });
+      assert.strictEqual(matching.length, 2);
+      assert.strictEqual(matching[0]?.id, 'http://test-realm/card-1');
+      assert.strictEqual(matching[1]?.id, 'http://test-realm/cards/1');
+    });
+
+    skip('can combine multiple types');
+    skip('can sort in alphabetical order');
+    skip('can sort in reverse alphabetical order');
+    skip('can sort in multiple string field conditions');
+    skip('can sort by multiple string field conditions in given directions');
+    skip('can sort by integer value');
+    skip('can sort by date');
+    skip('can sort by mixed field types');
+    skip(`can sort on multiple paths in combination with 'any' filter`);
+    skip(`can sort on multiple paths in combination with 'every' filter`);
   });
 });

--- a/host/tests/unit/search-index-test.ts
+++ b/host/tests/unit/search-index-test.ts
@@ -706,37 +706,45 @@ module('Unit | search-index', function () {
       await indexer.run();
     });
 
-    test('can filter cards by using `eq` on attributes', async function (assert) {
+    test('can filter cards by id', async function (assert) {
       let matching = await indexer.search({
-        filter: { eq: { name: 'card 1' } },
+        filter: {
+          eq: {
+            id: 'http://test-realm/card-1',
+          },
+        },
       });
-      assert.strictEqual(matching.length, 2);
-      assert.strictEqual(matching[0].id, 'http://test-realm/card-1');
+      assert.strictEqual(matching.length, 1, 'found one card');
+      assert.strictEqual(
+        matching[0]?.id,
+        'http://test-realm/card-1',
+        'card id is correct'
+      );
     });
 
     test('can use `eq` filter on multiple fields', async function (assert) {
       let matching = await indexer.search({
         filter: {
           eq: {
-            name: 'card 1',
-            type: 'article',
+            'attributes.name': 'card 1',
+            'attributes.type': 'article',
           },
         },
       });
       assert.strictEqual(matching.length, 1);
-      assert.strictEqual(matching[0].id, 'http://test-realm/cards/1');
+      assert.strictEqual(matching[0]?.id, 'http://test-realm/cards/1');
     });
 
-    test('can filter on a nested field using eq', async function (assert) {
+    test('can filter on a deeply nested field using `eq`', async function (assert) {
       let matching = await indexer.search({
         filter: {
           eq: {
-            'author.email': 'carl@stack.com',
+            'attributes.author.email': 'carl@stack.com',
           },
         },
       });
       assert.strictEqual(matching.length, 1);
-      assert.strictEqual(matching[0].id, 'http://test-realm/cards/2');
+      assert.strictEqual(matching[0]?.id, 'http://test-realm/cards/2');
     });
   });
 });

--- a/runtime-common/json-validation.ts
+++ b/runtime-common/json-validation.ts
@@ -1,0 +1,41 @@
+export function assertJSONValue(v: any, pointer: string[]) {
+  if (v === null) {
+    return;
+  }
+  switch (typeof v) {
+    case "string":
+    case "number":
+    case "boolean":
+      return;
+    case "object":
+      if (Array.isArray(v)) {
+        v.every((value, index) =>
+          assertJSONValue(value, pointer.concat(`[${index}]`))
+        );
+      } else {
+        Object.entries(v).every(([key, value]) =>
+          assertJSONValue(value, pointer.concat(key))
+        );
+      }
+      return;
+  }
+  throw new Error(`${pointer.join("/")}: value not allowed in json`);
+}
+
+export function assertJSONPrimitive(p: any, pointer: string[]) {
+  if (p === null) {
+    return;
+  }
+  switch (typeof p) {
+    case "string":
+    case "number":
+    case "boolean":
+      return;
+    default:
+      throw new Error(
+        `${pointer.join(
+          "/"
+        )}: JSON primitive must be of type string, number, boolean, or null`
+      );
+  }
+}

--- a/runtime-common/query.ts
+++ b/runtime-common/query.ts
@@ -1,0 +1,316 @@
+import * as JSON from "json-typescript";
+import isEqual from "lodash/isEqual";
+import { assertJSONValue, assertJSONPrimitive } from "./json-validation";
+import qs from "qs";
+
+export interface Query {
+  filter?: Filter;
+  sort?: Sort;
+  page?: { size?: number | string; cursor?: string };
+  queryString?: string;
+}
+
+export type CardURL = string;
+export type Filter =
+  | AnyFilter
+  | EveryFilter
+  | NotFilter
+  | EqFilter
+  | RangeFilter
+  | CardTypeFilter;
+
+export interface TypedFilter {
+  on?: CardURL;
+}
+
+interface SortExpression {
+  by: string;
+  on: CardURL;
+  direction?: "asc" | "desc";
+}
+
+export type Sort = SortExpression[];
+
+// The CardTypeFilter is used when you solely want to filter for all cards that
+// adopt from some particular card type--no other predicates are included in
+// this filter.
+export interface CardTypeFilter {
+  type: CardURL;
+}
+
+export interface AnyFilter extends TypedFilter {
+  any: Filter[];
+}
+
+export interface EveryFilter extends TypedFilter {
+  every: Filter[];
+}
+
+export interface NotFilter extends TypedFilter {
+  not: Filter;
+}
+
+export interface EqFilter extends TypedFilter {
+  eq: { [fieldName: string]: JSON.Value };
+}
+
+export interface RangeFilter extends TypedFilter {
+  range: {
+    [fieldName: string]: {
+      gt?: JSON.Primitive;
+      gte?: JSON.Primitive;
+      lt?: JSON.Primitive;
+      lte?: JSON.Primitive;
+    };
+  };
+}
+
+export function parseQueryString(querystring: string): Query {
+  let query = qs.parse(querystring);
+  assertQuery(query);
+  return query;
+}
+
+export function buildQueryString(query: Query): string {
+  return `?${qs.stringify(query)}`;
+}
+
+export function assertQuery(
+  query: any,
+  pointer: string[] = [""]
+): asserts query is Query {
+  if (typeof query !== "object" || query == null) {
+    throw new Error(`${pointer.join("/") || "/"}: missing query object`);
+  }
+
+  if ("filter" in query) {
+    assertFilter(query.filter, pointer.concat("filter"));
+  }
+
+  if (
+    "sort" in query &&
+    typeof query.sort !== "string" &&
+    (!Array.isArray(query.sort) ||
+      query.sort.some((i: any) => typeof i !== "string"))
+  ) {
+    throw new Error(
+      `${
+        pointer.concat("sort").join("/") || "/"
+      }: sort must be a string or string array`
+    );
+  }
+
+  if ("queryString" in query && typeof query.queryString !== "string") {
+    throw new Error(
+      `${
+        pointer.concat("queryString").join("/") || "/"
+      }: queryString must be a string`
+    );
+  }
+
+  if ("page" in query) {
+    assertPage(query.page, pointer.concat("page"));
+  }
+}
+
+function assertPage(
+  page: any,
+  pointer: string[]
+): asserts page is Query["page"] {
+  if (typeof page !== "object" || page == null) {
+    throw new Error(`${pointer.join("/") || "/"}: missing page object`);
+  }
+
+  if ("size" in page) {
+    if (
+      (typeof page.size !== "number" && typeof page.size !== "string") ||
+      (typeof page.size === "string" && isNaN(page.size))
+    ) {
+      throw new Error(
+        `${pointer.concat("size").join("/") || "/"}: size must be a number`
+      );
+    }
+  }
+
+  if ("cursor" in page && typeof page.cursor !== "string") {
+    throw new Error(
+      `${pointer.concat("cursor").join("/") || "/"}: cursor must be a string`
+    );
+  }
+}
+
+function assertFilter(
+  filter: any,
+  pointer: string[]
+): asserts filter is Filter {
+  if (typeof filter !== "object" || filter == null) {
+    throw new Error(`${pointer.join("/") || "/"}: missing filter object`);
+  }
+
+  if ("type" in filter) {
+    assertCardId(filter.type, pointer.concat("type"));
+    if (isEqual(Object.keys(filter), ["type"])) {
+      return; // This is a pure card type filter
+    }
+  }
+
+  if ("on" in filter) {
+    assertCardId(filter.on, pointer.concat("on"));
+  }
+
+  if ("any" in filter) {
+    assertAnyFilter(filter, pointer);
+  } else if ("every" in filter) {
+    assertEveryFilter(filter, pointer);
+  } else if ("not" in filter) {
+    assertNotFilter(filter, pointer);
+  } else if ("eq" in filter) {
+    assertEqFilter(filter, pointer);
+  } else if ("range" in filter) {
+    assertRangeFilter(filter, pointer);
+  } else {
+    throw new Error(
+      `${pointer.join("/") || "/"}: cannot determine the type of filter`
+    );
+  }
+}
+
+function assertCardId(id: any, pointer: string[]): asserts id is CardURL {
+  if (typeof id !== "string") {
+    throw new Error(
+      `${pointer.join("/") || "/"}: card id must be a string URL`
+    );
+  }
+}
+
+function assertAnyFilter(
+  filter: any,
+  pointer: string[]
+): asserts filter is AnyFilter {
+  if (typeof filter !== "object" || filter == null) {
+    throw new Error(`${pointer.join("/") || "/"}: filter must be an object`);
+  }
+  pointer.concat("any");
+  if (!("any" in filter)) {
+    throw new Error(
+      `${pointer.join("/") || "/"}: AnyFilter must have any property`
+    );
+  }
+
+  if (!Array.isArray(filter.any)) {
+    throw new Error(
+      `${pointer.join("/") || "/"}: any must be an array of Filters`
+    );
+  } else {
+    filter.any.every((value: any, index: number) =>
+      assertFilter(value, pointer.concat(`[${index}]`))
+    );
+  }
+}
+
+function assertEveryFilter(
+  filter: any,
+  pointer: string[]
+): asserts filter is EveryFilter {
+  if (typeof filter !== "object" || filter == null) {
+    throw new Error(`${pointer.join("/") || "/"}: filter must be an object`);
+  }
+  pointer.concat("every");
+  if (!("every" in filter)) {
+    throw new Error(
+      `${pointer.join("/") || "/"}: EveryFilter must have every property`
+    );
+  }
+
+  if (!Array.isArray(filter.every)) {
+    throw new Error(
+      `${pointer.join("/") || "/"}: every must be an array of Filters`
+    );
+  } else {
+    filter.every.every((value: any, index: number) =>
+      assertFilter(value, pointer.concat(`[${index}]`))
+    );
+  }
+}
+
+function assertNotFilter(
+  filter: any,
+  pointer: string[]
+): asserts filter is NotFilter {
+  if (typeof filter !== "object" || filter == null) {
+    throw new Error(`${pointer.join("/") || "/"}: filter must be an object`);
+  }
+  pointer.concat("not");
+  if (!("not" in filter)) {
+    throw new Error(
+      `${pointer.join("/") || "/"}: NotFilter must have not property`
+    );
+  }
+
+  assertFilter(filter.not, pointer);
+}
+
+function assertEqFilter(
+  filter: any,
+  pointer: string[]
+): asserts filter is EqFilter {
+  if (typeof filter !== "object" || filter == null) {
+    throw new Error(`${pointer.join("/") || "/"}: filter must be an object`);
+  }
+  pointer.concat("eq");
+  if (!("eq" in filter)) {
+    throw new Error(
+      `${pointer.concat("eq").join("/") || "/"}: EqFilter must have eq property`
+    );
+  }
+  if (typeof filter.eq !== "object" || filter.eq == null) {
+    throw new Error(`${pointer.join("/") || "/"}: eq must be an object`);
+  }
+  Object.entries(filter.eq).every(([key, value]) =>
+    assertJSONValue(value, pointer.concat(key))
+  );
+}
+
+function assertRangeFilter(
+  filter: any,
+  pointer: string[]
+): asserts filter is RangeFilter {
+  if (typeof filter !== "object" || filter == null) {
+    throw new Error(`${pointer.join("/") || "/"}: filter must be an object`);
+  }
+  pointer.concat("range");
+  if (!("range" in filter)) {
+    throw new Error(
+      `${
+        pointer.concat("range").join("/") || "/"
+      }: RangeFilter must have range property`
+    );
+  }
+  if (typeof filter.range !== "object" || filter.range == null) {
+    throw new Error(`${pointer.join("/") || "/"}: range must be an object`);
+  }
+  Object.entries(filter.range).every(([fieldPath, constraints]) => {
+    let innerPointer = [...pointer, fieldPath];
+    if (typeof constraints !== "object" || constraints == null) {
+      throw new Error(
+        `${innerPointer.join("/") || "/"}: range constraint must be an object`
+      );
+    }
+    Object.entries(constraints).every(([key, value]) => {
+      switch (key) {
+        case "gt":
+        case "gte":
+        case "lt":
+        case "lte":
+          assertJSONPrimitive(value, innerPointer.concat(key));
+          return;
+        default:
+          throw new Error(
+            `${
+              innerPointer.join("/") || "/"
+            }: range item must be gt, gte, lt, or lte`
+          );
+      }
+    });
+  });
+}

--- a/runtime-common/query.ts
+++ b/runtime-common/query.ts
@@ -4,6 +4,7 @@ import { assertJSONValue, assertJSONPrimitive } from "./json-validation";
 import qs from "qs";
 
 export interface Query {
+  id?: string;
   filter?: Filter;
   sort?: Sort;
   page?: { size?: number | string; cursor?: string };
@@ -81,6 +82,10 @@ export function assertQuery(
 ): asserts query is Query {
   if (typeof query !== "object" || query == null) {
     throw new Error(`${pointer.join("/") || "/"}: missing query object`);
+  }
+
+  if ("id" in query) {
+    assertCardId(query.id, pointer.concat("id"));
   }
 
   if ("filter" in query) {

--- a/runtime-common/realm.ts
+++ b/runtime-common/realm.ts
@@ -339,7 +339,9 @@ export class Realm {
     }
 
     let url = this.#paths.fileURL(localPath);
-    let original = await this.#searchIndex.card(url);
+    let original = (
+      await this.#searchIndex.search({ filter: { eq: { id: url.href } } })
+    )[0];
     if (!original) {
       return notFound(request);
     }
@@ -374,7 +376,9 @@ export class Realm {
   private async getCard(request: Request): Promise<Response> {
     let localPath = this.#paths.local(new URL(request.url));
     let url = this.#paths.fileURL(localPath);
-    let data = await this.#searchIndex.card(url);
+    let data = (
+      await this.#searchIndex.search({ filter: { eq: { id: url.href } } })
+    )[0];
     if (!data) {
       return notFound(request);
     }
@@ -391,7 +395,9 @@ export class Realm {
 
   private async removeCard(request: Request): Promise<Response> {
     let url = new URL(request.url);
-    let data = await this.#searchIndex.card(url);
+    let data = (
+      await this.#searchIndex.search({ filter: { eq: { id: url.href } } })
+    )[0];
     if (!data) {
       return notFound(request);
     }

--- a/runtime-common/realm.ts
+++ b/runtime-common/realm.ts
@@ -339,9 +339,7 @@ export class Realm {
     }
 
     let url = this.#paths.fileURL(localPath);
-    let original = (
-      await this.#searchIndex.search({ filter: { eq: { id: url.href } } })
-    )[0];
+    let original = (await this.#searchIndex.search({ id: url.href }))[0];
     if (!original) {
       return notFound(request);
     }
@@ -376,9 +374,7 @@ export class Realm {
   private async getCard(request: Request): Promise<Response> {
     let localPath = this.#paths.local(new URL(request.url));
     let url = this.#paths.fileURL(localPath);
-    let data = (
-      await this.#searchIndex.search({ filter: { eq: { id: url.href } } })
-    )[0];
+    let data = (await this.#searchIndex.search({ id: url.href }))[0];
     if (!data) {
       return notFound(request);
     }
@@ -395,9 +391,7 @@ export class Realm {
 
   private async removeCard(request: Request): Promise<Response> {
     let url = new URL(request.url);
-    let data = (
-      await this.#searchIndex.search({ filter: { eq: { id: url.href } } })
-    )[0];
+    let data = (await this.#searchIndex.search({ id: url.href }))[0];
     if (!data) {
       return notFound(request);
     }

--- a/runtime-common/search-index.ts
+++ b/runtime-common/search-index.ts
@@ -483,13 +483,23 @@ export class SearchIndex {
   // TODO: complete these types
   async search(query: Query): Promise<CardResource[]> {
     assertQuery(query);
-    let results = [...this.instances.values()];
 
     if (!query || Object.keys(query).length === 0) {
-      return results;
+      return [...this.instances.values()];
+    }
+
+    let results = [];
+
+    if (query.id) {
+      let card = this.instances.get(new URL(query.id));
+      if (!card) {
+        return [];
+      }
+      results.push(card); // return here?
     }
 
     if (query.filter) {
+      results = results.length ? results : [...this.instances.values()];
       if ("eq" in query.filter) {
         for (let [key, value] of Object.entries(query.filter.eq)) {
           results = results.filter((c) => {
@@ -506,7 +516,6 @@ export class SearchIndex {
             }
           });
         }
-        return results;
       } else {
         throw new Error(
           `Query uses unimplemented filter: ${JSON.stringify(query.filter)}`
@@ -518,7 +527,7 @@ export class SearchIndex {
       throw new Error(`Query sorting is not yet implemented`);
     }
 
-    throw new Error(`Query is invalid: ${JSON.stringify(query)}`);
+    return results;
   }
 
   async typeOf(ref: CardRef): Promise<CardDefinition | undefined> {

--- a/runtime-common/search-index.ts
+++ b/runtime-common/search-index.ts
@@ -488,26 +488,16 @@ export class SearchIndex {
       return [...this.instances.values()];
     }
 
-    let results = [];
-
     if (query.id) {
       let card = this.instances.get(new URL(query.id));
-      if (!card) {
-        return [];
-      }
-      results.push(card); // return here?
+      return card ? [card] : [];
     }
 
     if (query.filter) {
-      results = results.length ? results : [...this.instances.values()];
-      results = filterCardData(query.filter, results);
+      return filterCardData(query.filter, [...this.instances.values()]);
     }
 
-    if (query.sort) {
-      throw new Error(`Query sorting is not yet implemented`);
-    }
-
-    return results;
+    throw new Error("Not implemented");
   }
 
   async typeOf(ref: CardRef): Promise<CardDefinition | undefined> {
@@ -661,6 +651,10 @@ function filterCardData(
   results: CardResource[],
   opts?: { negate?: true }
 ): CardResource[] {
+  if (!("not" in filter) && !("eq" in filter)) {
+    throw new Error("Not implemented");
+  }
+
   if ("not" in filter) {
     results = filterCardData(filter.not, results, { negate: true });
   }

--- a/runtime-common/search-index.ts
+++ b/runtime-common/search-index.ts
@@ -495,14 +495,14 @@ export class SearchIndex {
           results = results.filter((c) => {
             let fields = key.split(".");
             if (fields.length > 1) {
-              let compValue = c.attributes;
+              let compValue = c as Record<string, any>;
               while (fields.length > 0 && compValue) {
                 let field = fields.shift();
                 compValue = compValue?.[field!];
               }
               return compValue === value;
             } else {
-              return c.attributes?.[key] === value;
+              return (c as Record<string, any>)[key] === value;
             }
           });
         }
@@ -535,10 +535,6 @@ export class SearchIndex {
     url: URL
   ): Promise<{ name: string; kind: Kind }[] | undefined> {
     return this.directories.get(url);
-  }
-  // TODO merge this into the .search() API after we get the queries working
-  async card(url: URL): Promise<CardResource | undefined> {
-    return this.instances.get(url);
   }
 
   // TODO merge this into the .search() API after we get the queries working


### PR DESCRIPTION
Some discussion needed on whether `eq` should be able to search any key in a card resource or only within `card.attributes`, which is more similar to what we're returning in the monorepo version. Including the id search in this function became somewhat conceptually confusing, since there's only 1 card per id, so there's no benefit to having it be present along with the filter, sort, etc features of the search function, but we still have to check for those options in case the user sends in a search query with an id and another filter because we're allowing it.

It was awkward to type `.search({filter { eq: { id: '...' }}}` each time, so created a shorter way to get id: `.search({ id: '...' })`. There're some complications with the types when returning a single card or undefined, so the search function still returns an array. I'm open to changing all of these according to the team's suggestions.

- Also I ported over the `query` types & validation and `json-validation` over from the monorepo. Did the obvious changes, but I'm sure there're more changes to make to make them fit our needs.