### PR TITLE
Search doc support (searches against computed fields) and indexing instances with modules in external realms

### DIFF
--- a/base/card-api.gts
+++ b/base/card-api.gts
@@ -155,6 +155,35 @@ export function serializeCard<CardT extends CardConstructor>(model: InstanceType
   return resource;
 }
 
+export async function searchDoc<CardT extends CardConstructor>(model: InstanceType<CardT>): Promise<Record<string, any>> {
+  await recompute(model);
+
+  let result: Record<string, any> = {};
+  for (let fieldName of Object.keys(getFields(model))) {
+    // TODO we'll want to use a "queryValue" card field feature here
+    let value = serializedGet(model, fieldName);
+    if (value) {
+      result[fieldName] = value;
+    }
+  }
+  let searchDoc = flatten(result);
+  return searchDoc;
+}
+
+function flatten(obj: Record<string, any>): Record<string, any> {
+  let result: Record<string, any> = {};
+  for (let [key, value] of Object.entries(obj)) {
+    if (typeof value === "object") {
+      let res = flatten(value);
+      for (let [k, val] of Object.entries(res)) {
+        result[`${key}.${k}`] = val;
+      }
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
 
 class ContainsMany<FieldT extends CardConstructor> implements Field<FieldT> {
   constructor(

--- a/host/tests/cards/article.gts
+++ b/host/tests/cards/article.gts
@@ -1,0 +1,7 @@
+import { contains, field } from 'https://cardstack.com/base/card-api';
+import DatetimeCard from 'https://cardstack.com/base/datetime';
+import { Post } from './post';
+
+export class Article extends Post {
+  @field publishedDate = contains(DatetimeCard);
+}

--- a/host/tests/cards/book.gts
+++ b/host/tests/cards/book.gts
@@ -1,0 +1,6 @@
+import { contains, field, Card } from 'https://cardstack.com/base/card-api';
+import { Person } from './person';
+
+export class Book extends Card {
+  @field author = contains(Person);
+}

--- a/host/tests/cards/person.gts
+++ b/host/tests/cards/person.gts
@@ -3,6 +3,12 @@ import StringCard from "https://cardstack.com/base/string";
 
 export class Person extends Card {
   @field firstName = contains(StringCard);
+  @field lastName = contains(StringCard);
+  @field email = contains(StringCard);
+  @field fullName = contains(StringCard, { computeVia: async function(this: Person) {
+    await new Promise(resolve => setTimeout(resolve, 10));
+    return `${this.firstName ?? ''} ${this.lastName ?? ''}`;
+  }});
   static isolated = class Isolated extends Component<typeof this> {
     <template><h1><@fields.firstName/></h1></template>
   }

--- a/host/tests/cards/post.gts
+++ b/host/tests/cards/post.gts
@@ -1,10 +1,15 @@
 import { contains, field, Component, Card } from "https://cardstack.com/base/card-api";
 import StringCard from "https://cardstack.com/base/string";
+import IntegerCard from 'https://cardstack.com/base/integer';
+import DatetimeCard from 'https://cardstack.com/base/datetime';
 import { Person } from "./person";
 
 export class Post extends Card {
   @field title = contains(StringCard);
+  @field description = contains(StringCard);
   @field author = contains(Person);
+  @field views = contains(IntegerCard);
+  @field createdAt = contains(DatetimeCard);
   static isolated = class Isolated extends Component<typeof this> {
     <template><h1><@fields.title/> by <@fields.author.firstName/></h1></template>
   }

--- a/host/tests/helpers/index.ts
+++ b/host/tests/helpers/index.ts
@@ -21,15 +21,13 @@ export const TestRealm = {
     return new Realm(
       realmURL ?? testRealmURL,
       new TestRealmAdapter(flatFiles),
-      'http://localhost:4201/base/'
+      { baseRealmURL: 'http://localhost:4201/base/' }
     );
   },
   createWithAdapter(adapter: RealmAdapter, realmURL?: string): Realm {
-    return new Realm(
-      realmURL ?? testRealmURL,
-      adapter,
-      'http://localhost:4201/base/'
-    );
+    return new Realm(realmURL ?? testRealmURL, adapter, {
+      baseRealmURL: 'http://localhost:4201/base/',
+    });
   },
 };
 

--- a/host/tests/integration/components/schema-test.gts
+++ b/host/tests/integration/components/schema-test.gts
@@ -3,18 +3,19 @@ import GlimmerComponent from '@glimmer/component';
 import { CardRef, baseRealm } from '@cardstack/runtime-common';
 import { setupRenderingTest } from 'ember-qunit';
 import { renderComponent } from '../../helpers/render-component';
-import { testRealmURL } from '../../helpers';
 import Schema from 'runtime-spike/components/schema';
 import Service from '@ember/service';
 import { waitUntil } from '@ember/test-helpers';
 
+const testRealmURL = 'http://localhost:4201/test/'
+
 // TODO Consider making this a helper
 class NodeRealm extends Service {
   isAvailable = true;
-  url = new URL('http://localhost:4201/test/');
+  url = new URL(testRealmURL);
   realmMappings = new Map([
     [baseRealm.url, 'http://localhost:4201/base/'],
-    [testRealmURL, 'http://localhost:4201/test/']
+    [testRealmURL, testRealmURL]
   ])
   mapURL(url: string, reverseLookup = false) {
     for (let [realm, forwardURL] of this.realmMappings) {

--- a/host/tests/unit/realm-test.ts
+++ b/host/tests/unit/realm-test.ts
@@ -8,9 +8,14 @@ import {
   compiledCard,
 } from '@cardstack/runtime-common/etc/test-fixtures';
 import { TestRealm, TestRealmAdapter, testRealmURL } from '../helpers';
+import { Loader } from '@cardstack/runtime-common/loader';
 import { stringify } from 'qs';
 
-module('Unit | realm', function () {
+module('Unit | realm', function (hooks) {
+  hooks.before(function () {
+    Loader.destroy();
+  });
+
   test('realm can serve card data requests', async function (assert) {
     let adapter = new TestRealmAdapter({
       'dir/empty.json': {
@@ -252,8 +257,8 @@ module('Unit | realm', function () {
           },
           meta: {
             adoptsFrom: {
-              module: 'https://cardstack.com/base/card-api',
-              name: 'Card',
+              module: 'http://localhost:4201/test/person',
+              name: 'Person',
             },
           },
         },
@@ -276,8 +281,8 @@ module('Unit | realm', function () {
               },
               meta: {
                 adoptsFrom: {
-                  module: 'https://cardstack.com/base/card-api',
-                  name: 'Card',
+                  module: 'http://localhost:4201/test/person',
+                  name: 'Person',
                 },
               },
             },
@@ -325,8 +330,8 @@ module('Unit | realm', function () {
             },
             meta: {
               adoptsFrom: {
-                module: 'https://cardstack.com/base/card-api',
-                name: 'Card',
+                module: 'http://localhost:4201/test/person',
+                name: 'Person',
               },
             },
           },

--- a/host/tests/unit/search-index-test.ts
+++ b/host/tests/unit/search-index-test.ts
@@ -2,10 +2,15 @@ import { module, test, skip } from 'qunit';
 import { TestRealm, TestRealmAdapter, testRealmURL } from '../helpers';
 import { RealmPaths } from '@cardstack/runtime-common/paths';
 import { SearchIndex } from '@cardstack/runtime-common/search-index';
+import { Loader } from '@cardstack/runtime-common/loader';
 
 let paths = new RealmPaths(testRealmURL);
 
-module('Unit | search-index', function () {
+module('Unit | search-index', function (hooks) {
+  hooks.before(function () {
+    Loader.destroy();
+  });
+
   test('full indexing discovers card instances', async function (assert) {
     let adapter = new TestRealmAdapter({
       'empty.json': {
@@ -643,55 +648,32 @@ posts/ignore-me.gts
     );
   });
 
+  const testModuleRealm = 'http://localhost:4201/test/';
   module('query', function (hooks) {
     const sampleCards = {
-      'cards.gts': `
-        import { contains, field, Card } from 'https://cardstack.com/base/card-api';
-        import StringCard from 'https://cardstack.com/base/string';
-        import IntegerCard from 'https://cardstack.com/base/integer';
-        import DatetimeCard from 'https://cardstack.com/base/datetime';
-
-        export class Person extends Card {
-          @field name = contains(StringCard);
-          @field email = contains(StringCard);
-        }
-
-        export class Post extends Card {
-          @field title = contains(StringCard);
-          @field description = contains(StringCard);
-          @field author = contains(Person);
-          @fields views = contains(IntegerCard);
-          @fields createdAt = contains(DatetimeCard);
-        }
-
-        export class Article extends Post {
-          @fields publishedDate = contains(DatetimeCard);
-        }
-      `,
-      'book.gts': `
-        import { contains, field, Card } from 'https://cardstack.com/base/card-api';
-        import Person from './cards.gts';
-
-        export class Book extends Card {
-          @field author = contains(Person);
-        }
-      `,
       'card-1.json': {
         data: {
           type: 'card',
           attributes: {
             title: 'Card 1',
             description: 'Sample post',
-            author: { name: 'Cardy' },
+            author: { firstName: 'Cardy' },
           },
-          meta: { adoptsFrom: { module: `./cards`, name: 'Article' } },
+          meta: {
+            adoptsFrom: {
+              module: `${testModuleRealm}article`,
+              name: 'Article',
+            },
+          },
         },
       },
       'card-2.json': {
         data: {
           type: 'card',
-          attributes: { author: { name: 'Cardy' } },
-          meta: { adoptsFrom: { module: `./book.gts`, name: 'Book' } },
+          attributes: { author: { firstName: 'Cardy' } },
+          meta: {
+            adoptsFrom: { module: `${testModuleRealm}book`, name: 'Book' },
+          },
         },
       },
       'cards/1.json': {
@@ -700,12 +682,12 @@ posts/ignore-me.gts
           attributes: {
             title: 'Card 1',
             description: 'Sample post',
-            author: { name: 'Carl Stack' },
+            author: { firstName: 'Carl', lastName: 'Stack' },
             createdAt: new Date(2022, 7, 1),
             views: 10,
           },
           meta: {
-            adoptsFrom: { module: `${paths.url}cards`, name: 'Post' },
+            adoptsFrom: { module: `${testModuleRealm}post`, name: 'Post' },
           },
         },
       },
@@ -716,14 +698,18 @@ posts/ignore-me.gts
             title: 'Card 2',
             description: 'Sample post',
             author: {
-              name: 'Carl Stack',
+              firstName: 'Carl',
+              lastName: 'Deck',
               email: 'carl@stack.com',
             },
             createdAt: new Date(2022, 7, 22),
             views: 5,
           },
           meta: {
-            adoptsFrom: { module: `${paths.url}cards`, name: 'Article' },
+            adoptsFrom: {
+              module: `${testModuleRealm}article`,
+              name: 'Article',
+            },
           },
         },
       },
@@ -740,7 +726,7 @@ posts/ignore-me.gts
     test(`can search for cards by using the 'eq' filter`, async function (assert) {
       let matching = await indexer.search({
         filter: {
-          on: { module: `${paths.url}cards`, name: 'Post' },
+          on: { module: `${testModuleRealm}post`, name: 'Post' },
           eq: { title: 'Card 1', description: 'Sample post' },
         },
       });
@@ -750,13 +736,26 @@ posts/ignore-me.gts
       );
     });
 
+    test(`can search for cards by using a computed field`, async function (assert) {
+      let matching = await indexer.search({
+        filter: {
+          on: { module: `${testModuleRealm}post`, name: 'Post' },
+          eq: { 'author.fullName': 'Carl Stack' },
+        },
+      });
+      assert.deepEqual(
+        matching.map((m) => m.id),
+        [`${paths.url}cards/1`]
+      );
+    });
+
     test('can combine multiple filters', async function (assert) {
       let matching = await indexer.search({
         filter: {
           every: [
-            { type: { module: `${paths.url}cards`, name: 'Post' } },
+            { type: { module: `${testModuleRealm}post`, name: 'Post' } },
             { eq: { title: 'Card 1' } },
-            { not: { eq: { 'author.name': 'Cardy' } } },
+            { not: { eq: { 'author.firstName': 'Cardy' } } },
           ],
         },
       });
@@ -767,7 +766,7 @@ posts/ignore-me.gts
     test('can handle a filter with double negatives', async function (assert) {
       let matching = await indexer.search({
         filter: {
-          on: { module: `${paths.url}cards`, name: 'Post' },
+          on: { module: `${testModuleRealm}post`, name: 'Post' },
           not: { not: { not: { eq: { 'author.email': 'carl@stack.com' } } } },
         },
       });
@@ -779,7 +778,9 @@ posts/ignore-me.gts
 
     test('can filter by card type', async function (assert) {
       let matching = await indexer.search({
-        filter: { type: { module: `${paths.url}cards`, name: 'Article' } },
+        filter: {
+          type: { module: `${testModuleRealm}article`, name: 'Article' },
+        },
       });
       assert.deepEqual(
         matching.map((m) => m.id),
@@ -788,7 +789,7 @@ posts/ignore-me.gts
       );
 
       matching = await indexer.search({
-        filter: { type: { module: `${testRealmURL}cards`, name: 'Post' } },
+        filter: { type: { module: `${testModuleRealm}post`, name: 'Post' } },
       });
       assert.deepEqual(
         matching.map((m) => m.id),
@@ -804,8 +805,8 @@ posts/ignore-me.gts
     test(`can filter on a nested field using 'eq'`, async function (assert) {
       let matching = await indexer.search({
         filter: {
-          on: { module: `${paths.url}cards`, name: 'Post' },
-          eq: { 'author.name': 'Carl Stack' },
+          on: { module: `${testModuleRealm}post`, name: 'Post' },
+          eq: { 'author.firstName': 'Carl' },
         },
       });
       assert.deepEqual(
@@ -818,7 +819,7 @@ posts/ignore-me.gts
       let matching = await indexer.search({
         filter: {
           every: [
-            { type: { module: `${paths.url}cards`, name: 'Article' } },
+            { type: { module: `${testModuleRealm}article`, name: 'Article' } },
             { not: { eq: { 'author.email': 'carl@stack.com' } } },
           ],
         },
@@ -832,12 +833,12 @@ posts/ignore-me.gts
         filter: {
           any: [
             {
-              on: { module: `${paths.url}cards.gts`, name: 'Article' },
-              eq: { 'author.name': 'Cardy' },
+              on: { module: `${testModuleRealm}article`, name: 'Article' },
+              eq: { 'author.firstName': 'Cardy' },
             },
             {
-              on: { module: `${paths.url}book`, name: 'Book' },
-              eq: { 'author.name': 'Cardy' },
+              on: { module: `${testModuleRealm}book`, name: 'Book' },
+              eq: { 'author.firstName': 'Cardy' },
             },
           ],
         },

--- a/realm-server/main.ts
+++ b/realm-server/main.ts
@@ -8,6 +8,7 @@ let {
   port,
   path: paths,
   url: urls,
+  canonicalURL: canonicalURLs,
   baseRealmURL,
 } = yargs(process.argv.slice(2))
   .usage("Start realm server")
@@ -19,6 +20,12 @@ let {
     },
     url: {
       description: "realm URL",
+      demandOption: true,
+      type: "array",
+    },
+    canonicalURL: {
+      description:
+        "the canonical URL for the realm (which may be different than the URL the realm is hosted at). If this is set to an empty value then it will default to the 'url' parameter",
       demandOption: true,
       type: "array",
     },
@@ -35,27 +42,30 @@ let {
   })
   .parseSync();
 
-if (urls.length !== paths.length) {
+if (!(urls.length === paths.length && urls.length === canonicalURLs.length)) {
   console.error(
-    `Mismatched number of paths and URLs specified. Each --path argument must be paired with a --url argument`
+    `Mismatched number of paths, URLs, and canonicalURLs specified. Each --path argument must be paired with a --url argument and a --canonicalURL argument`
   );
   process.exit(-1);
 }
 
-let realms: Realm[] = paths.map(
-  (path, i) =>
-    new Realm(
-      String(urls[i]),
-      new NodeAdapter(resolve(String(path))),
-      baseRealmURL
-    )
-);
+let realms: Realm[] = paths.map((path, i) => {
+  let url = new URL(String(urls[i]), `http://localhost:${port}`).href;
+  let canonicalURL: string = new URL(
+    String(canonicalURLs[i] || url),
+    `http://localhost:${port}`
+  ).href;
+  return new Realm(canonicalURL, new NodeAdapter(resolve(String(path))), {
+    baseRealmURL,
+    hostedAtURL: url,
+  });
+});
 
 let server = createRealmServer(realms);
 server.listen(port);
 console.log(
   `Realm server listening on port ${port} with base realm of ${baseRealmURL}:`
 );
-for (let [index, { url }] of realms.entries()) {
-  console.log(`  ${paths[index]} => ${url}`);
+for (let [index, { url, hostedAtURL }] of realms.entries()) {
+  console.log(`  ${paths[index]} => ${hostedAtURL} canonical url (${url})`);
 }

--- a/realm-server/package.json
+++ b/realm-server/package.json
@@ -27,9 +27,9 @@
   "scripts": {
     "test": "NODE_NO_WARNINGS=1 qunit --require ts-node/register tests/index.ts",
     "start": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main",
-    "start:base": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4201 --path='../base' --url='https://cardstack.com/base/' --baseRealmURL='http://localhost:4201/base/'",
-    "start:base-and-host-test-realm": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4201 --path='../base' --url='https://cardstack.com/base/' --path='../host/tests/cards' --url='http://test-realm/test/' --baseRealmURL='http://localhost:4201/base/'",
-    "start:test-node-realm": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4202 --url='http://test-realm/node-test/' --path='./tests/cards' --baseRealmURL='http://localhost:4201/base/'",
+    "start:base": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4201 --path='../base' --url='/base/' --canonicalURL='https://cardstack.com/base/' --baseRealmURL='http://localhost:4201/base/'",
+    "start:base-and-host-test-realm": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4201 --path='../base' --url='/base/' --canonicalURL='https://cardstack.com/base/' --path='../host/tests/cards' --url='/test/' --canonicalURL= --baseRealmURL='http://localhost:4201/base/'",
+    "start:test-node-realm": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4202 --url='/node-test/' --canonicalURL= --path='./tests/cards' --baseRealmURL='http://localhost:4201/base/'",
     "start:test-realms": "NODE_NO_WARNINGS=1 start-server-and-test 'start:base-and-host-test-realm' 'http-get://localhost:4201/base/card-api' 'start:test-node-realm' 'http-get://localhost:4202/node-test/person' 'wait'",
     "wait": "sleep 10000000"
   }

--- a/realm-server/tests/realm-server-test.ts
+++ b/realm-server/tests/realm-server-test.ts
@@ -36,7 +36,7 @@ module("Realm Server", function (hooks) {
     let testRealm = new Realm(
       testRealmHref,
       new NodeAdapter(resolve(dir.name)),
-      "http://localhost:4201/base/"
+      { baseRealmURL: "http://localhost:4201/base/" }
     );
     await testRealm.ready;
     server = createRealmServer([testRealm]);
@@ -419,11 +419,9 @@ module("Realm Server", function (hooks) {
 
   test("can dynamically load a card from own realm", async function (assert) {
     let nodeRealm = new NodeAdapter(dir.name);
-    let realm = new Realm(
-      "http://test-realm/",
-      nodeRealm,
-      "http://localhost:4201/base/"
-    );
+    let realm = new Realm("http://test-realm/", nodeRealm, {
+      baseRealmURL: "http://localhost:4201/base/",
+    });
     await realm.ready;
 
     let module = await realm.loader.load<Record<string, any>>(

--- a/runtime-common/realm.ts
+++ b/runtime-common/realm.ts
@@ -112,7 +112,7 @@ export class Realm {
       .post("/", this.createCard.bind(this))
       .patch("/.+(?<!.json)", this.patchCard.bind(this))
       .get("/_search", this.search.bind(this))
-      // TODO lets move typeOf and cardsOf to be a path you add to the end of a route like realmInfo
+      // TODO lets move cardsOf to be a path you add to the end of a route like typeOf
       .get("/_cardsOf", this.getCardsOf.bind(this))
       .get("/.*_realmInfo", this.getRealmInfo.bind(this))
       .get("/.*_typeOf", this.getTypeOf.bind(this))

--- a/runtime-common/search-index.ts
+++ b/runtime-common/search-index.ts
@@ -322,10 +322,9 @@ export class SearchIndex {
             new URL(localPath, this.realm.hostedAtURL)
           );
           let card = CardClass.fromSerialized(json.data.attributes);
-          let searchData = await this.api.searchDoc(card);
           this.instances.set(instanceURL, {
             resource: json.data,
-            searchData,
+            searchData: await this.api.searchDoc(card),
             types: undefined,
           });
         }

--- a/worker/src/main.ts
+++ b/worker/src/main.ts
@@ -27,7 +27,7 @@ livenessWatcher.registerShutdownListener(async () => {
       new Realm(
         'http://local-realm/',
         new LocalRealm(messageHandler.fs),
-        'http://localhost:4201/base/' // This is the locally served base realm
+        { baseRealmURL: 'http://localhost:4201/base/' } // This is the locally served base realm
       )
     );
   } catch (err) {


### PR DESCRIPTION
This introduces:
-  The ability to create a search doc from a card model, which the search index has been updated to do
- This also adds the ability to index cards whose modules live in external realms (besides the base realm). 
- Minor command line cleanup as well so the full URL doesn't need to be specified on the command line
- As well as I've updated no longer making the hosted test realm appear as "http://test-realm/test/" in the host tests--we're just using "http://localhost:4201/test/" for it.

note that all the search index query tests have been adjusted so that they import modules from the hosted test server since we need to dynamically load card modules in order to generate search docs for our cards in the index.

TODO:
-  [ ] need to rewrite `import.meta` on the server since the service worker won't understand this. The service worker loads modules using AMD, so `import.meta` won't work in this context.