### PR TITLE
Loader refactor

### DIFF
--- a/base/card-ref.gts
+++ b/base/card-ref.gts
@@ -30,7 +30,7 @@ class BaseView extends Component<typeof CardRefCard> {
     if (!this.args.model) {
       return;
     }
-    let module: Record<string, any> = await Loader.getLoader().load(this.args.model.module);
+    let module: Record<string, any> = await Loader.getLoader().import(this.args.model.module);
     let Clazz: typeof Card = module[this.args.model.name];
     this.card = Clazz.fromSerialized({...(Clazz as any).demo ?? {}});
   }

--- a/base/card-ref.gts
+++ b/base/card-ref.gts
@@ -30,7 +30,7 @@ class BaseView extends Component<typeof CardRefCard> {
     if (!this.args.model) {
       return;
     }
-    let module: Record<string, any> = await Loader.getLoader().import(this.args.model.module);
+    let module: Record<string, any> = await Loader.import(this.args.model.module);
     let Clazz: typeof Card = module[this.args.model.name];
     this.card = Clazz.fromSerialized({...(Clazz as any).demo ?? {}});
   }

--- a/host/app/app.ts
+++ b/host/app/app.ts
@@ -2,7 +2,15 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'runtime-spike/config/environment';
+import { Loader } from '@cardstack/runtime-common/loader';
+import { baseRealm } from '@cardstack/runtime-common';
 import './lib/glint-embroider-workaround';
+
+// This is the locally served base realm
+Loader.addURLMapping(
+  new URL(baseRealm.url),
+  new URL('http://localhost:4201/base/')
+);
 
 /* The following modules are made available to cards as external modules.
  * This is paired with the worker/src/externals.ts file which is responsible

--- a/host/app/components/card-editor.gts
+++ b/host/app/components/card-editor.gts
@@ -6,7 +6,7 @@ import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import isEqual from 'lodash/isEqual';
 import { eq } from '../helpers/truth-helpers';
-import { restartableTask } from 'ember-concurrency';
+import { restartableTask, task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import { registerDestructor } from '@ember/destroyable';
 import { CardJSON, isCardJSON, isCardDocument } from '@cardstack/runtime-common';
@@ -19,7 +19,7 @@ import type { Card, Format, } from 'https://cardstack.com/base/card-api';
 export interface NewCardArgs {
   type: 'new';
   realmURL: string;
-  context: {
+  cardSource: {
     module: string;
     name: string;
   };
@@ -89,15 +89,17 @@ export default class Preview extends Component<Signature> {
   rendered: RenderedCard | undefined;
   @tracked
   initialCardData: CardJSON | undefined;
-  private interval: ReturnType<typeof setInterval>;
+  private declare interval: ReturnType<typeof setInterval>;
   private lastModified: number | undefined;
 
   constructor(owner: unknown, args: Signature['Args']) {
     super(owner, args);
     if (this.args.card.type === 'existing') {
       taskFor(this.loadData).perform(this.args.card.url);
+      this.interval = setInterval(() => taskFor(this.loadData).perform((this.args.card as any).url), 1000);
+    } else {
+      taskFor(this.prepareNewInstance).perform();
     }
-    this.interval = setInterval(() => taskFor(this.loadData).perform((this.args.card as any).url), 1000);
     registerDestructor(this, () => clearInterval(this.interval));
   }
 
@@ -105,7 +107,7 @@ export default class Preview extends Component<Signature> {
   get card() {
     this.resetTime; // just consume this
     if (this.args.card.type === 'new') {
-      let cardClass = this.args.module[this.args.card.context.name];
+      let cardClass = this.args.module[this.args.card.cardSource.name];
       return new cardClass();
     }
     if (this.initialCardData) {
@@ -123,7 +125,7 @@ export default class Preview extends Component<Signature> {
       }
       json = {
         data: this.cardAPI.api.serializeCard(this.card, {
-          adoptsFrom: this.args.card.context,
+          adoptsFrom: this.args.card.cardSource,
         })
       };
     } else {
@@ -177,6 +179,13 @@ export default class Preview extends Component<Signature> {
   @action
   save() {
     taskFor(this.write).perform();
+  }
+
+  @task private async prepareNewInstance(): Promise<void> {
+    await this.cardAPI.loaded;
+    if (!this.rendered) {
+      this.rendered = this.cardAPI.render(this, () => this.card, () => this.format);
+    }
   }
 
   @restartableTask private async loadData(url: string | undefined): Promise<void> {

--- a/host/app/components/card-editor.gts
+++ b/host/app/components/card-editor.gts
@@ -10,6 +10,7 @@ import { restartableTask } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import { registerDestructor } from '@ember/destroyable';
 import { CardJSON, isCardJSON, isCardDocument } from '@cardstack/runtime-common';
+import { Loader } from '@cardstack/runtime-common/loader';
 import RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';
 import CardAPI, { RenderedCard } from '../services/card-api';
@@ -192,7 +193,7 @@ export default class Preview extends Component<Signature> {
       return;
     }
 
-    let response = await fetch(url, {
+    let response = await Loader.fetch(url, {
       headers: {
         'Accept': 'application/vnd.api+json'
       },
@@ -216,7 +217,7 @@ export default class Preview extends Component<Signature> {
   @restartableTask private async write(): Promise<void> {
     let url = this.args.card.type === 'new' ? this.args.card.realmURL : this.args.card.url;
     let method = this.args.card.type === 'new' ? 'POST' : 'PATCH';
-    let response = await fetch(url, {
+    let response = await Loader.fetch(url, {
       method,
       headers: {
         'Accept': 'application/vnd.api+json'

--- a/host/app/components/go.gts
+++ b/host/app/components/go.gts
@@ -18,6 +18,7 @@ import {
   languageConfigs
 } from '../utils/editor-language';
 import { isCardJSON } from '@cardstack/runtime-common';
+import { Loader } from '@cardstack/runtime-common/loader';
 import type { Format } from 'https://cardstack.com/base/card-api';
 import type { FileResource } from '../resources/file';
 
@@ -133,7 +134,7 @@ export default class Go extends Component<Signature> {
 
   @restartableTask private async remove(url: string): Promise<void> {
     let headersAccept = url.endsWith('.json') ? 'application/vnd.api+json' : 'application/vnd.card+source';
-    let response = await fetch(url, { method: 'DELETE', headers: { 'Accept': headersAccept }});
+    let response = await Loader.fetch(url, { method: 'DELETE', headers: { 'Accept': headersAccept }});
     if (!response.ok) {
       throw new Error(`could not delete file, status: ${response.status} - ${response.statusText}. ${await response.text()}`);
     }

--- a/host/app/components/schema.gts
+++ b/host/app/components/schema.gts
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import LocalRealm from '../services/local-realm';
 import { RealmPaths } from '@cardstack/runtime-common/paths';
+import { Loader } from '@cardstack/runtime-common/loader';
 //@ts-ignore cached not available yet in definitely typed
 import { cached } from '@glimmer/tracking';
 import { tracked } from '@glimmer/tracking';
@@ -79,7 +80,7 @@ export default class Schema extends Component<Signature> {
     if (!this.localRealm.isAvailable) {
       throw new Error('Local realm is not available');
     }
-    return new RealmPaths(this.localRealm.mapURL(this.localRealm.url.href, true));
+    return new RealmPaths(Loader.reverseResolution(this.localRealm.url.href));
   }
 
   @action

--- a/host/app/components/schema.gts
+++ b/host/app/components/schema.gts
@@ -30,7 +30,7 @@ export default class Schema extends Component<Signature> {
         <ImportModule @url={{this.cardType.type.exportedCardContext.module}}>
           <:ready as |module|>
             <CardEditor
-              @card={{hash type="new" realmURL=this.localRealm.url.href context=this.cardType.type.exportedCardContext}}
+              @card={{hash type="new" realmURL=this.localRealm.url.href cardSource=this.cardType.type.exportedCardContext}}
               @module={{module}}
               @onSave={{this.onSave}}
               @onCancel={{this.onCancel}}

--- a/host/app/config/environment.d.ts
+++ b/host/app/config/environment.d.ts
@@ -11,7 +11,5 @@ declare const config: {
   locationType: 'history' | 'hash' | 'none' | 'auto';
   rootURL: string;
   APP: Record<string, unknown>;
-  'ember-cli-mirage': {
-    enabled: boolean;
-  };
+  isCli: boolean;
 };

--- a/host/app/config/environment.d.ts
+++ b/host/app/config/environment.d.ts
@@ -11,5 +11,4 @@ declare const config: {
   locationType: 'history' | 'hash' | 'none' | 'auto';
   rootURL: string;
   APP: Record<string, unknown>;
-  isCli: boolean;
 };

--- a/host/app/resources/card-refs.ts
+++ b/host/app/resources/card-refs.ts
@@ -3,6 +3,7 @@ import { restartableTask } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import { tracked } from '@glimmer/tracking';
 import { CardRef } from '@cardstack/runtime-common';
+import { Loader } from '@cardstack/runtime-common/loader';
 import { stringify } from 'qs';
 import { service } from '@ember/service';
 import LocalRealm from '../services/local-realm';
@@ -27,7 +28,7 @@ export class CardRefs extends Resource<Args> {
   }
 
   @restartableTask private async getCardRefs(module: string) {
-    let response = await fetch(
+    let response = await Loader.fetch(
       `${this.localRealmURL.href}_cardsOf?${stringify({
         module,
       })}`,

--- a/host/app/resources/card-type.ts
+++ b/host/app/resources/card-type.ts
@@ -3,6 +3,7 @@ import { restartableTask } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import { tracked } from '@glimmer/tracking';
 import { CardRef } from '@cardstack/runtime-common';
+import { Loader } from '@cardstack/runtime-common/loader';
 import {
   CardDefinitionResource,
   getExportedCardContext,
@@ -83,7 +84,7 @@ export class CardType extends Resource<Args> {
   }
 
   private async load(typeOfURL: string): Promise<CardDefinitionResource> {
-    let response = await fetch(this.localRealm.mapURL(typeOfURL), {
+    let response = await Loader.fetch(typeOfURL, {
       headers: {
         Accept: 'application/vnd.api+json',
       },

--- a/host/app/resources/directory.ts
+++ b/host/app/resources/directory.ts
@@ -7,6 +7,7 @@ import { taskFor } from 'ember-concurrency-ts';
 import flatMap from 'lodash/flatMap';
 import { DirectoryEntryRelationship } from '@cardstack/runtime-common';
 import { RealmPaths } from '@cardstack/runtime-common/paths';
+import { Loader } from '@cardstack/runtime-common/loader';
 import LocalRealm from '../services/local-realm';
 
 interface Args {
@@ -76,7 +77,7 @@ async function getEntries(
   url: string
 ): Promise<Entry[]> {
   let response: Response | undefined;
-  response = await fetch(url, {
+  response = await Loader.fetch(url, {
     headers: { Accept: 'application/vnd.api+json' },
   });
   if (!response.ok) {

--- a/host/app/resources/file.ts
+++ b/host/app/resources/file.ts
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { restartableTask, TaskInstance } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import { registerDestructor } from '@ember/destroyable';
+import { Loader } from '@cardstack/runtime-common/loader';
 
 interface Args {
   named: {
@@ -76,7 +77,7 @@ class _FileResource extends Resource<Args> {
 
   @restartableTask private async read() {
     let prevState = this.state;
-    let response = await fetch(this.url, {
+    let response = await Loader.fetch(this.url, {
       headers: {
         Accept: 'application/vnd.card+source',
       },
@@ -114,7 +115,7 @@ class _FileResource extends Resource<Args> {
   }
 
   @restartableTask private async doWrite(content: string) {
-    let response = await fetch(this.url, {
+    let response = await Loader.fetch(this.url, {
       method: 'POST',
       headers: {
         Accept: 'application/vnd.card+source',

--- a/host/app/resources/import.ts
+++ b/host/app/resources/import.ts
@@ -1,5 +1,6 @@
 import { Resource, useResource } from 'ember-resources';
 import { tracked } from '@glimmer/tracking';
+import { Loader } from '@cardstack/runtime-common/loader';
 
 interface Args {
   named: { url: string };
@@ -22,11 +23,11 @@ export class ImportResource extends Resource<Args> {
 
   private async load(url: string) {
     try {
-      let m = await import(/* webpackIgnore: true */ url);
+      let m = await Loader.import(url);
       moduleURLs.set(m, url);
       this.module = m;
     } catch (err) {
-      let errResponse = await fetch(url, {
+      let errResponse = await Loader.fetch(url, {
         headers: { 'content-type': 'text/javascript' },
       });
       if (!errResponse.ok) {

--- a/host/app/resources/import.ts
+++ b/host/app/resources/import.ts
@@ -22,13 +22,12 @@ export class ImportResource extends Resource<Args> {
   }
 
   private async load(url: string) {
-    let absoluteURL = new URL(url, 'http://localhost:4200');
     try {
-      let m = await Loader.import(absoluteURL.href);
+      let m = await Loader.import(url);
       moduleURLs.set(m, url);
       this.module = m;
     } catch (err) {
-      let errResponse = await Loader.fetch(absoluteURL, {
+      let errResponse = await Loader.fetch(url, {
         headers: { 'content-type': 'text/javascript' },
       });
       if (!errResponse.ok) {

--- a/host/app/resources/import.ts
+++ b/host/app/resources/import.ts
@@ -22,12 +22,13 @@ export class ImportResource extends Resource<Args> {
   }
 
   private async load(url: string) {
+    let absoluteURL = new URL(url, 'http://localhost:4200');
     try {
-      let m = await Loader.import(url);
+      let m = await Loader.import(absoluteURL.href);
       moduleURLs.set(m, url);
       this.module = m;
     } catch (err) {
-      let errResponse = await Loader.fetch(url, {
+      let errResponse = await Loader.fetch(absoluteURL, {
         headers: { 'content-type': 'text/javascript' },
       });
       if (!errResponse.ok) {

--- a/host/app/routes/application.ts
+++ b/host/app/routes/application.ts
@@ -5,6 +5,7 @@ import { file, FileResource } from '../resources/file';
 import type RouterService from '@ember/routing/router-service';
 import LocalRealm from '../services/local-realm';
 import { RealmPaths } from '@cardstack/runtime-common/paths';
+import { Loader } from '@cardstack/runtime-common/loader';
 
 interface Model {
   path: string | undefined;
@@ -35,7 +36,7 @@ export default class Application extends Route<Model> {
 
     let realmPath = new RealmPaths(this.localRealm.url);
     let url = realmPath.fileURL(path).href;
-    let response = await fetch(url, {
+    let response = await Loader.fetch(url, {
       headers: {
         Accept: 'application/vnd.card+source',
       },

--- a/host/config/environment.js
+++ b/host/config/environment.js
@@ -44,7 +44,6 @@ module.exports = function (environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
-    ENV.isCli = process.env.CLI_TEST === 'true';
   }
 
   if (environment === 'production') {

--- a/host/config/environment.js
+++ b/host/config/environment.js
@@ -44,9 +44,7 @@ module.exports = function (environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
-    ENV['ember-cli-mirage'] = {
-      enabled: true,
-    };
+    ENV.isCli = process.env.CLI_TEST === 'true';
   }
 
   if (environment === 'production') {

--- a/host/package.json
+++ b/host/package.json
@@ -20,9 +20,7 @@
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
     "test": "npm-run-all lint test:*",
-    "ember-test": "CLI_TEST=true ember test",
-    "test:ember": "start-server-and-test serve-test-modules 4203 ember-test",
-    "serve-test-modules": "npx http-server --port 4203 --cors='*' ./public"
+    "test:ember": "ember test"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",
@@ -127,7 +125,6 @@
     "qs": "^6.10.5",
     "qunit": "^2.18.0",
     "qunit-dom": "^2.0.0",
-    "start-server-and-test": "^1.14.0",
     "tracked-built-ins": "^2.0.1",
     "typescript": "^4.6.3",
     "webpack": "^5.69.1"

--- a/host/package.json
+++ b/host/package.json
@@ -20,7 +20,9 @@
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
     "test": "npm-run-all lint test:*",
-    "test:ember": "ember test"
+    "ember-test": "CLI_TEST=true ember test",
+    "test:ember": "start-server-and-test serve-test-modules 4203 ember-test",
+    "serve-test-modules": "npx http-server --port 4203 --cors='*' ./public"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",
@@ -125,6 +127,7 @@
     "qs": "^6.10.5",
     "qunit": "^2.18.0",
     "qunit-dom": "^2.0.0",
+    "start-server-and-test": "^1.14.0",
     "tracked-built-ins": "^2.0.1",
     "typescript": "^4.6.3",
     "webpack": "^5.69.1"

--- a/host/tests/helpers/index.ts
+++ b/host/tests/helpers/index.ts
@@ -1,6 +1,13 @@
 import { parse } from 'date-fns';
-import { Realm, Kind, RealmAdapter, FileRef } from '@cardstack/runtime-common';
+import {
+  Realm,
+  Kind,
+  RealmAdapter,
+  FileRef,
+  baseRealm,
+} from '@cardstack/runtime-common';
 import { RealmPaths, LocalPath } from '@cardstack/runtime-common/paths';
+import { Loader } from '@cardstack/runtime-common/loader';
 
 export function cleanWhiteSpace(text: string) {
   return text.replace(/\s+/g, ' ').trim();
@@ -16,18 +23,18 @@ export interface Dir {
 
 export const testRealmURL = 'http://test-realm/test/';
 
+// This is the locally served base realm
+Loader.addURLMapping(
+  new URL(baseRealm.url),
+  new URL('http://localhost:4201/base/')
+);
+
 export const TestRealm = {
   create(flatFiles: Record<string, string | object>, realmURL?: string): Realm {
-    return new Realm(
-      realmURL ?? testRealmURL,
-      new TestRealmAdapter(flatFiles),
-      { baseRealmURL: 'http://localhost:4201/base/' }
-    );
+    return new Realm(realmURL ?? testRealmURL, new TestRealmAdapter(flatFiles));
   },
   createWithAdapter(adapter: RealmAdapter, realmURL?: string): Realm {
-    return new Realm(realmURL ?? testRealmURL, adapter, {
-      baseRealmURL: 'http://localhost:4201/base/',
-    });
+    return new Realm(realmURL ?? testRealmURL, adapter);
   },
 };
 

--- a/host/tests/helpers/render-component.ts
+++ b/host/tests/helpers/render-component.ts
@@ -3,13 +3,13 @@ import { precompileTemplate } from '@ember/template-compilation';
 import { render } from '@ember/test-helpers';
 import { ComponentLike } from '@glint/template';
 import type { Card, Format } from 'https://cardstack.com/base/card-api';
+import { Loader } from '@cardstack/runtime-common/loader';
+import { baseRealm } from '@cardstack/runtime-common';
 
 async function cardApi(): Promise<
   typeof import('https://cardstack.com/base/card-api')
 > {
-  return await import(
-    /* webpackIgnore: true */ 'http://localhost:4201/base/card-api' + ''
-  );
+  return await Loader.import(`${baseRealm.url}card-api`);
 }
 
 export async function renderComponent(C: ComponentLike) {

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -5,8 +5,10 @@ import { renderCard } from '../../helpers/render-component';
 import { cleanWhiteSpace, p, testRealmURL } from '../../helpers';
 import parseISO from 'date-fns/parseISO';
 import { on } from '@ember/modifier';
+import { baseRealm, } from "@cardstack/runtime-common";
+import { Loader } from '@cardstack/runtime-common/loader';
+import type { ExportedCardRef, } from "@cardstack/runtime-common";
 import type { SignatureFor, primitive as primitiveType } from "https://cardstack.com/base/card-api";
-import type { ExportedCardRef } from "@cardstack/runtime-common";
 
 
 let cardApi: typeof import("https://cardstack.com/base/card-api");
@@ -22,14 +24,14 @@ module('Integration | card-basics', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(async function () {
-    cardApi = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/card-api' + '');
+    cardApi = await Loader.import(`${baseRealm.url}card-api`);
     primitive = cardApi.primitive;
-    string = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/string' + '');
-    integer = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/integer' + '');
-    date = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/date' + '');
-    datetime = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/datetime' + '');
-    cardRef = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/card-ref' + '');
-    pickModule = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/pick' + '');
+    string = await Loader.import(`${baseRealm.url}string`);
+    integer = await Loader.import(`${baseRealm.url}integer`);
+    date = await Loader.import(`${baseRealm.url}date`);
+    datetime = await Loader.import(`${baseRealm.url}datetime`);
+    cardRef = await Loader.import(`${baseRealm.url}card-ref`);
+    pickModule = await Loader.import(`${baseRealm.url}pick`);
   });
 
   test('primitive field type checking', async function (assert) {
@@ -693,7 +695,7 @@ module('Integration | card-basics', function (hooks) {
 });
 
 async function testString(label: string) {
-  cardApi = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/card-api' + '');
+  cardApi = await Loader.import(`${baseRealm.url}card-api`);
   let {Card, Component } = cardApi;
   return class TestString extends Card {
     static [primitive]: string;

--- a/host/tests/integration/components/card-editor-test.gts
+++ b/host/tests/integration/components/card-editor-test.gts
@@ -5,6 +5,8 @@ import { setupRenderingTest } from 'ember-qunit';
 import CardEditor, { ExistingCardArgs }  from 'runtime-spike/components/card-editor';
 import { renderComponent } from '../../helpers/render-component';
 import { testRealmURL } from '../../helpers';
+import { Loader } from '@cardstack/runtime-common/loader';
+import { baseRealm } from '@cardstack/runtime-common';
 import type { Format } from "https://cardstack.com/base/card-api";
 
 let cardApi: typeof import("https://cardstack.com/base/card-api");
@@ -15,8 +17,8 @@ module('Integration | card-editor', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(async function () {
-    cardApi = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/card-api' + '');
-    string = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/string' + '');
+    cardApi = await Loader.import(`${baseRealm.url}card-api`);
+    string = await Loader.import(`${baseRealm.url}string`);
   });
 
   test('renders card', async function (assert) {

--- a/host/tests/integration/components/computed-test.gts
+++ b/host/tests/integration/components/computed-test.gts
@@ -5,6 +5,8 @@ import { fillIn } from '@ember/test-helpers';
 import waitUntil from '@ember/test-helpers/wait-until';
 import find from '@ember/test-helpers/dom/find';
 import { cleanWhiteSpace } from '../../helpers';
+import { Loader } from '@cardstack/runtime-common/loader';
+import { baseRealm } from '@cardstack/runtime-common';
 
 let cardApi: typeof import("https://cardstack.com/base/card-api");
 let string: typeof import ("https://cardstack.com/base/string");
@@ -13,8 +15,8 @@ module('Integration | computeds', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(async function () {
-    cardApi = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/card-api' + '');
-    string = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/string' + '');
+    cardApi = await Loader.import(`${baseRealm.url}card-api`);
+    string = await Loader.import(`${baseRealm.url}string`);
   });
 
   test('can render a synchronous computed field', async function(assert) {

--- a/host/tests/integration/components/import-module-test.gts
+++ b/host/tests/integration/components/import-module-test.gts
@@ -3,6 +3,16 @@ import { waitFor } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import { renderComponent } from '../../helpers/render-component';
 import ImportModule from 'runtime-spike/components/import-module';
+import config from 'runtime-spike/config/environment';
+import { Loader } from '@cardstack/runtime-common/loader';
+
+// It appears that we are unable to load modules from localhost:4200 when tests
+// run from the CLI. So instead we are explicitly running an http-server on 4203 in
+// the CLI for these tests. Sadly we can't put these modules into our realm server,
+// since the realm serve currently refuses to host broken modules (which will be
+// addressed in the future).
+const host = config.isCli ? 'http://localhost:4203/' : 'http://localhost:4200/';
+Loader.addURLMapping(new URL("http://module-host/"), new URL(host));
 
 module('Integration | import-module', function (hooks) {
   setupRenderingTest(hooks);
@@ -10,7 +20,7 @@ module('Integration | import-module', function (hooks) {
   test('yields a successfully loaded module', async function (assert) {
     await renderComponent(
       <template>
-        <ImportModule @url="/test-modules/good.js">
+        <ImportModule @url="http://module-host/test-modules/good.js">
           <:ready as |module|>
             <h1 data-test-ready>{{module.message}}</h1>
           </:ready>
@@ -25,7 +35,7 @@ module('Integration | import-module', function (hooks) {
   test('yields module loading errors', async function (assert) {
     await renderComponent(
       <template>
-        <ImportModule @url="/test-modules/bad.js">
+        <ImportModule @url="http://module-host/test-modules/bad.js">
           <:error as |err|>
             <div data-test-type>{{err.type}}</div>
             <div data-test-message>{{err.message}}</div>

--- a/host/tests/integration/components/import-module-test.gts
+++ b/host/tests/integration/components/import-module-test.gts
@@ -10,7 +10,7 @@ module('Integration | import-module', function (hooks) {
   test('yields a successfully loaded module', async function (assert) {
     await renderComponent(
       <template>
-        <ImportModule @url="/test-modules/good.js">
+        <ImportModule @url="http://localhost:4200/test-modules/good.js">
           <:ready as |module|>
             <h1 data-test-ready>{{module.message}}</h1>
           </:ready>
@@ -25,7 +25,7 @@ module('Integration | import-module', function (hooks) {
   test('yields module loading errors', async function (assert) {
     await renderComponent(
       <template>
-        <ImportModule @url="/test-modules/bad.js">
+        <ImportModule @url="http://localhost:4200/test-modules/bad.js">
           <:error as |err|>
             <div data-test-type>{{err.type}}</div>
             <div data-test-message>{{err.message}}</div>

--- a/host/tests/integration/components/import-module-test.gts
+++ b/host/tests/integration/components/import-module-test.gts
@@ -12,7 +12,7 @@ import { Loader } from '@cardstack/runtime-common/loader';
 // since the realm serve currently refuses to host broken modules (which will be
 // addressed in the future).
 const host = config.isCli ? 'http://localhost:4203/' : 'http://localhost:4200/';
-Loader.addURLMapping(new URL("http://module-host/"), new URL(host));
+Loader.addURLMapping(new URL("http://module-host"), new URL(window.origin));
 
 module('Integration | import-module', function (hooks) {
   setupRenderingTest(hooks);

--- a/host/tests/integration/components/import-module-test.gts
+++ b/host/tests/integration/components/import-module-test.gts
@@ -10,7 +10,7 @@ module('Integration | import-module', function (hooks) {
   test('yields a successfully loaded module', async function (assert) {
     await renderComponent(
       <template>
-        <ImportModule @url="http://localhost:4200/test-modules/good.js">
+        <ImportModule @url="/test-modules/good.js">
           <:ready as |module|>
             <h1 data-test-ready>{{module.message}}</h1>
           </:ready>
@@ -25,7 +25,7 @@ module('Integration | import-module', function (hooks) {
   test('yields module loading errors', async function (assert) {
     await renderComponent(
       <template>
-        <ImportModule @url="http://localhost:4200/test-modules/bad.js">
+        <ImportModule @url="/test-modules/bad.js">
           <:error as |err|>
             <div data-test-type>{{err.type}}</div>
             <div data-test-message>{{err.message}}</div>

--- a/host/tests/integration/components/import-module-test.gts
+++ b/host/tests/integration/components/import-module-test.gts
@@ -3,15 +3,9 @@ import { waitFor } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import { renderComponent } from '../../helpers/render-component';
 import ImportModule from 'runtime-spike/components/import-module';
-import config from 'runtime-spike/config/environment';
 import { Loader } from '@cardstack/runtime-common/loader';
 
-// It appears that we are unable to load modules from localhost:4200 when tests
-// run from the CLI. So instead we are explicitly running an http-server on 4203 in
-// the CLI for these tests. Sadly we can't put these modules into our realm server,
-// since the realm serve currently refuses to host broken modules (which will be
-// addressed in the future).
-const host = config.isCli ? 'http://localhost:4203/' : 'http://localhost:4200/';
+// testem will serve on a different port than ember cli, so use this mapping
 Loader.addURLMapping(new URL("http://module-host"), new URL(window.origin));
 
 module('Integration | import-module', function (hooks) {

--- a/host/tests/integration/components/schema-test.gts
+++ b/host/tests/integration/components/schema-test.gts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import GlimmerComponent from '@glimmer/component';
-import { CardRef, baseRealm } from '@cardstack/runtime-common';
+import { CardRef } from '@cardstack/runtime-common';
 import { setupRenderingTest } from 'ember-qunit';
 import { renderComponent } from '../../helpers/render-component';
 import Schema from 'runtime-spike/components/schema';
@@ -9,25 +9,9 @@ import { waitUntil } from '@ember/test-helpers';
 
 const testRealmURL = 'http://localhost:4201/test/'
 
-// TODO Consider making this a helper
 class NodeRealm extends Service {
   isAvailable = true;
   url = new URL(testRealmURL);
-  realmMappings = new Map([
-    [baseRealm.url, 'http://localhost:4201/base/'],
-    [testRealmURL, testRealmURL]
-  ])
-  mapURL(url: string, reverseLookup = false) {
-    for (let [realm, forwardURL] of this.realmMappings) {
-      if (!reverseLookup && url.startsWith(realm)) {
-        return url.replace(realm, forwardURL);
-      }
-      if (reverseLookup && url.startsWith(forwardURL)) {
-        return url.replace(forwardURL, realm);
-      }
-    }
-    return url;
-  }
 }
 
 module('Integration | schema', function (hooks) {

--- a/host/tests/integration/components/serialization-test.gts
+++ b/host/tests/integration/components/serialization-test.gts
@@ -5,6 +5,8 @@ import { fillIn } from '@ember/test-helpers';
 import { renderCard } from '../../helpers/render-component';
 import parseISO from 'date-fns/parseISO';
 import { p, cleanWhiteSpace } from '../../helpers';
+import { Loader } from '@cardstack/runtime-common/loader';
+import { baseRealm } from '@cardstack/runtime-common';
 
 let cardApi: typeof import("https://cardstack.com/base/card-api");
 let string: typeof import ("https://cardstack.com/base/string");
@@ -17,12 +19,12 @@ module('Integration | serialization', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(async function () {
-    cardApi = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/card-api' + '');
-    string = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/string' + '');
-    integer = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/integer' + '');
-    date = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/date' + '');
-    datetime = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/datetime' + '');
-    cardRef = await import(/* webpackIgnore: true */ 'http://localhost:4201/base/card-ref' + '');
+    cardApi = await Loader.import(`${baseRealm.url}card-api`);
+    string = await Loader.import(`${baseRealm.url}string`);
+    integer = await Loader.import(`${baseRealm.url}integer`);
+    date = await Loader.import(`${baseRealm.url}date`);
+    datetime = await Loader.import(`${baseRealm.url}datetime`);
+    cardRef = await Loader.import(`${baseRealm.url}card-ref`);
   });
 
   test('can deserialize field', async function (assert) {

--- a/host/tests/unit/realm-test.ts
+++ b/host/tests/unit/realm-test.ts
@@ -796,7 +796,6 @@ module('Unit | realm', function () {
           attributes: {
             cardExports: [
               {
-                type: 'exportedCard',
                 module: `${testRealmURL}person`,
                 name: 'Person',
               },

--- a/host/tests/unit/realm-test.ts
+++ b/host/tests/unit/realm-test.ts
@@ -8,14 +8,9 @@ import {
   compiledCard,
 } from '@cardstack/runtime-common/etc/test-fixtures';
 import { TestRealm, TestRealmAdapter, testRealmURL } from '../helpers';
-import { Loader } from '@cardstack/runtime-common/loader';
 import { stringify } from 'qs';
 
-module('Unit | realm', function (hooks) {
-  hooks.before(function () {
-    Loader.destroy();
-  });
-
+module('Unit | realm', function () {
   test('realm can serve card data requests', async function (assert) {
     let adapter = new TestRealmAdapter({
       'dir/empty.json': {

--- a/host/tests/unit/search-index-test.ts
+++ b/host/tests/unit/search-index-test.ts
@@ -62,7 +62,6 @@ module('Unit | search-index', function () {
     let refs = await indexer.exportedCardsOf('person.gts');
     assert.deepEqual(refs, [
       {
-        type: 'exportedCard',
         module: `${testRealmURL}person`,
         name: 'FancyPerson',
       },

--- a/host/tests/unit/search-index-test.ts
+++ b/host/tests/unit/search-index-test.ts
@@ -2,15 +2,10 @@ import { module, test, skip } from 'qunit';
 import { TestRealm, TestRealmAdapter, testRealmURL } from '../helpers';
 import { RealmPaths } from '@cardstack/runtime-common/paths';
 import { SearchIndex } from '@cardstack/runtime-common/search-index';
-import { Loader } from '@cardstack/runtime-common/loader';
 
 let paths = new RealmPaths(testRealmURL);
 
-module('Unit | search-index', function (hooks) {
-  hooks.before(function () {
-    Loader.destroy();
-  });
-
+module('Unit | search-index', function () {
   test('full indexing discovers card instances', async function (assert) {
     let adapter = new TestRealmAdapter({
       'empty.json': {

--- a/realm-server/main.ts
+++ b/realm-server/main.ts
@@ -1,4 +1,5 @@
 import { Realm } from "@cardstack/runtime-common";
+import { Loader } from "@cardstack/runtime-common/loader";
 import { NodeAdapter } from "./node-realm";
 import yargs from "yargs";
 import { createRealmServer } from "./server";
@@ -54,11 +55,10 @@ let urlMappings = new Map(
     new URL(String(toUrls[i]), `http://localhost:${port}`),
   ])
 );
+Loader.getLoader({ urlMappings });
 let hrefs = [...urlMappings].map(([from, to]) => [from.href, to.href]);
 let realms: Realm[] = paths.map((path, i) => {
-  return new Realm(hrefs[i][0], new NodeAdapter(resolve(String(path))), {
-    urlMappings,
-  });
+  return new Realm(hrefs[i][0], new NodeAdapter(resolve(String(path))));
 });
 
 let server = createRealmServer(realms);

--- a/realm-server/main.ts
+++ b/realm-server/main.ts
@@ -49,14 +49,14 @@ if (fromUrls.length < paths.length) {
   process.exit(-1);
 }
 
-let urlMappings = new Map(
-  fromUrls.map((fromUrl, i) => [
-    new URL(String(fromUrl), `http://localhost:${port}`),
-    new URL(String(toUrls[i]), `http://localhost:${port}`),
-  ])
-);
-Loader.getLoader({ urlMappings });
-let hrefs = [...urlMappings].map(([from, to]) => [from.href, to.href]);
+let urlMappings = fromUrls.map((fromUrl, i) => [
+  new URL(String(fromUrl), `http://localhost:${port}`),
+  new URL(String(toUrls[i]), `http://localhost:${port}`),
+]);
+for (let [from, to] of urlMappings) {
+  Loader.addURLMapping(from, to);
+}
+let hrefs = urlMappings.map(([from, to]) => [from.href, to.href]);
 let realms: Realm[] = paths.map((path, i) => {
   return new Realm(hrefs[i][0], new NodeAdapter(resolve(String(path))));
 });

--- a/realm-server/package.json
+++ b/realm-server/package.json
@@ -27,10 +27,10 @@
   "scripts": {
     "test": "NODE_NO_WARNINGS=1 qunit --require ts-node/register tests/index.ts",
     "start": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main",
-    "start:base": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4201 --path='../base' --url='/base/' --canonicalURL='https://cardstack.com/base/' --baseRealmURL='http://localhost:4201/base/'",
-    "start:base-and-host-test-realm": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4201 --path='../base' --url='/base/' --canonicalURL='https://cardstack.com/base/' --path='../host/tests/cards' --url='/test/' --canonicalURL= --baseRealmURL='http://localhost:4201/base/'",
-    "start:test-node-realm": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4202 --url='/node-test/' --canonicalURL= --path='./tests/cards' --baseRealmURL='http://localhost:4201/base/'",
-    "start:test-realms": "NODE_NO_WARNINGS=1 start-server-and-test 'start:base-and-host-test-realm' 'http-get://localhost:4201/base/card-api' 'start:test-node-realm' 'http-get://localhost:4202/node-test/person' 'wait'",
+    "start:base": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4201 --path='../base' --fromUrl='https://cardstack.com/base/' --toUrl='/base/'",
+    "start:base-and-host-test-realms": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4201 --path='../base' --fromUrl='https://cardstack.com/base/' --toUrl='/base/' --path='../host/tests/cards' --fromUrl='/test/' --toUrl='/test/'",
+    "start:test-node-realm": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4202 --fromUrl='/node-test/' --toUrl='/node-test/' --path='./tests/cards' --fromUrl='https://cardstack.com/base/' --toUrl='http://localhost:4201/base/'",
+    "start:test-realms": "NODE_NO_WARNINGS=1 start-server-and-test 'start:base-and-host-test-realms' 'http-get://localhost:4201/base/card-api' 'start:test-node-realm' 'http-get://localhost:4202/node-test/person' 'wait'",
     "wait": "sleep 10000000"
   }
 }

--- a/realm-server/server.ts
+++ b/realm-server/server.ts
@@ -78,10 +78,6 @@ export function createRealmServer(realms: Realm[]) {
       } else if (body != null) {
         res.write(body);
       }
-    } catch (e) {
-      console.error("Unexpected server error: ", e);
-      res.statusCode = 500;
-      res.statusMessage = e.message;
     } finally {
       // the node pipe takes care of ending the response for us, so we only have
       // to do this when we are not piping

--- a/realm-server/tests/realm-server-test.ts
+++ b/realm-server/tests/realm-server-test.ts
@@ -34,15 +34,15 @@ module("Realm Server", function (hooks) {
   hooks.beforeEach(async function () {
     dir = dirSync();
     copySync(join(__dirname, "cards"), dir.name);
+    Loader.getLoader({
+      urlMappings: new Map([
+        [new URL(baseRealm.url), new URL("http://localhost:4201/base/")],
+      ]),
+    });
 
     let testRealm = new Realm(
       testRealmHref,
-      new NodeAdapter(resolve(dir.name)),
-      {
-        urlMappings: new Map([
-          [new URL(baseRealm.url), new URL("http://localhost:4201/base/")],
-        ]),
-      }
+      new NodeAdapter(resolve(dir.name))
     );
     await testRealm.ready;
     server = createRealmServer([testRealm]);
@@ -448,15 +448,11 @@ module("Realm Server", function (hooks) {
   });
 
   test("can dynamically load a card from own realm", async function (assert) {
-    let nodeRealm = new NodeAdapter(dir.name);
-    let realm = new Realm("http://test-realm/", nodeRealm, {
-      urlMappings: new Map([
-        [new URL(baseRealm.url), new URL("http://localhost:4201/base/")],
-      ]),
-    });
-    await realm.ready;
+    // let nodeRealm = new NodeAdapter(dir.name);
+    // let realm = new Realm("http://test-realm/", nodeRealm);
+    // await realm.ready;
 
-    let module = await realm.loader.import<Record<string, any>>(
+    let module = await Loader.getLoader().import<Record<string, any>>(
       `${testRealmHref}person`
     );
     let Person = module["Person"];

--- a/realm-server/tests/realm-server-test.ts
+++ b/realm-server/tests/realm-server-test.ts
@@ -26,6 +26,11 @@ const testRealmURL = new URL("http://127.0.0.1:4444/");
 const testRealmHref = testRealmURL.href;
 const testRealm2Href = "http://localhost:4202/node-test/";
 
+Loader.addURLMapping(
+  new URL(baseRealm.url),
+  new URL("http://localhost:4201/base/")
+);
+
 module("Realm Server", function (hooks) {
   let server: Server;
   let request: SuperTest<Test>;
@@ -34,10 +39,6 @@ module("Realm Server", function (hooks) {
   hooks.beforeEach(async function () {
     dir = dirSync();
     copySync(join(__dirname, "cards"), dir.name);
-    Loader.addURLMapping(
-      new URL(baseRealm.url),
-      new URL("http://localhost:4201/base/")
-    );
 
     let testRealm = new Realm(
       testRealmHref,

--- a/realm-server/tests/realm-server-test.ts
+++ b/realm-server/tests/realm-server-test.ts
@@ -34,11 +34,10 @@ module("Realm Server", function (hooks) {
   hooks.beforeEach(async function () {
     dir = dirSync();
     copySync(join(__dirname, "cards"), dir.name);
-    Loader.getLoader({
-      urlMappings: new Map([
-        [new URL(baseRealm.url), new URL("http://localhost:4201/base/")],
-      ]),
-    });
+    Loader.addURLMapping(
+      new URL(baseRealm.url),
+      new URL("http://localhost:4201/base/")
+    );
 
     let testRealm = new Realm(
       testRealmHref,
@@ -448,7 +447,7 @@ module("Realm Server", function (hooks) {
   });
 
   test("can dynamically load a card from own realm", async function (assert) {
-    let module = await Loader.getLoader().import<Record<string, any>>(
+    let module = await Loader.import<Record<string, any>>(
       `${testRealmHref}person`
     );
     let Person = module["Person"];
@@ -457,7 +456,7 @@ module("Realm Server", function (hooks) {
   });
 
   test("can dynamically load a card from a different realm", async function (assert) {
-    let module = await Loader.getLoader().import<Record<string, any>>(
+    let module = await Loader.import<Record<string, any>>(
       `${testRealm2Href}person`
     );
     let Person = module["Person"];
@@ -466,14 +465,14 @@ module("Realm Server", function (hooks) {
   });
 
   test("can dynamically modules with cycles", async function (assert) {
-    let module = await Loader.getLoader().import<{ three(): number }>(
+    let module = await Loader.import<{ three(): number }>(
       `${testRealm2Href}cycle-two`
     );
     assert.strictEqual(module.three(), 3);
   });
 
   test("can instantiate a card that uses a card-ref field", async function (assert) {
-    let module = await Loader.getLoader().import<Record<string, any>>(
+    let module = await Loader.import<Record<string, any>>(
       `${testRealm2Href}card-ref-test`
     );
     let TestCard = module["TestCard"];

--- a/realm-server/tests/realm-server-test.ts
+++ b/realm-server/tests/realm-server-test.ts
@@ -342,7 +342,6 @@ module("Realm Server", function (hooks) {
           attributes: {
             cardExports: [
               {
-                type: "exportedCard",
                 module: `${testRealmHref}person`,
                 name: "Person",
               },

--- a/realm-server/tests/realm-server-test.ts
+++ b/realm-server/tests/realm-server-test.ts
@@ -448,10 +448,6 @@ module("Realm Server", function (hooks) {
   });
 
   test("can dynamically load a card from own realm", async function (assert) {
-    // let nodeRealm = new NodeAdapter(dir.name);
-    // let realm = new Realm("http://test-realm/", nodeRealm);
-    // await realm.ready;
-
     let module = await Loader.getLoader().import<Record<string, any>>(
       `${testRealmHref}person`
     );

--- a/runtime-common/externals.ts
+++ b/runtime-common/externals.ts
@@ -1,42 +1,31 @@
 import type * as Babel from "@babel/core";
 import type { types as t } from "@babel/core";
 import type { NodePath } from "@babel/traverse";
-import { externalsMap, baseRealm } from "@cardstack/runtime-common";
-import type { Realm } from "@cardstack/runtime-common/realm";
-
-interface State {
-  opts: Options;
-  insideCard: boolean;
-}
-
-interface Options {
-  realm: Realm;
-}
+import { baseRealm, externalsMap } from "@cardstack/runtime-common";
+import { Loader } from "./loader";
 
 export function externalsPlugin(_babel: typeof Babel) {
   // let t = babel.types;
   return {
     visitor: {
       Program: {
-        exit(path: NodePath<t.Program>, state: State) {
-          let {
-            opts: { realm },
-          } = state;
-          let externalsURL = new URL("/externals/", realm.baseRealmURL);
+        exit(path: NodePath<t.Program>) {
+          let loader = Loader.getLoader();
+          let externalsURL = new URL(
+            "/externals/",
+            loader.resolve(baseRealm.url)
+          ).href;
           for (let topLevelPath of path.get("body")) {
             if (topLevelPath.isImportDeclaration()) {
               if (externalsMap.has(topLevelPath.node.source.value)) {
                 // rewrite the external to use the /externals route of the base
                 // realm that the realm was configured to talk to
-                topLevelPath.node.source.value = `${externalsURL.href}${topLevelPath.node.source.value}`;
-              } else if (
-                topLevelPath.node.source.value.startsWith(baseRealm.url)
-              ) {
-                // rewrite the canonical base realm URL's to use the base realm
-                // that the realm was configured to talk to
-                topLevelPath.node.source.value = `${
-                  realm.baseRealmURL
-                }${topLevelPath.node.source.value.slice(baseRealm.url.length)}`;
+                topLevelPath.node.source.value = `${externalsURL}${topLevelPath.node.source.value}`;
+              } else if (topLevelPath.node.source.value.startsWith("http")) {
+                // resolve the import path using the loader
+                topLevelPath.node.source.value = loader.resolve(
+                  topLevelPath.node.source.value
+                );
               }
             }
           }

--- a/runtime-common/externals.ts
+++ b/runtime-common/externals.ts
@@ -25,7 +25,7 @@ export function externalsPlugin(_babel: typeof Babel) {
                 // resolve the import path using the loader
                 topLevelPath.node.source.value = loader.resolve(
                   topLevelPath.node.source.value
-                );
+                ).href;
               }
             }
           }

--- a/runtime-common/externals.ts
+++ b/runtime-common/externals.ts
@@ -10,10 +10,9 @@ export function externalsPlugin(_babel: typeof Babel) {
     visitor: {
       Program: {
         exit(path: NodePath<t.Program>) {
-          let loader = Loader.getLoader();
           let externalsURL = new URL(
             "/externals/",
-            loader.resolve(baseRealm.url)
+            Loader.resolve(baseRealm.url)
           ).href;
           for (let topLevelPath of path.get("body")) {
             if (topLevelPath.isImportDeclaration()) {
@@ -23,7 +22,7 @@ export function externalsPlugin(_babel: typeof Babel) {
                 topLevelPath.node.source.value = `${externalsURL}${topLevelPath.node.source.value}`;
               } else if (topLevelPath.node.source.value.startsWith("http")) {
                 // resolve the import path using the loader
-                topLevelPath.node.source.value = loader.resolve(
+                topLevelPath.node.source.value = Loader.resolve(
                   topLevelPath.node.source.value
                 ).href;
               }

--- a/runtime-common/loader.ts
+++ b/runtime-common/loader.ts
@@ -76,14 +76,12 @@ export class Loader {
       Loader.#instance = new Loader(urlMappings, loader);
     } else {
       if (urlMappings) {
-        if (urlMappings) {
-          for (let [from, to] of urlMappings) {
-            Loader.#instance.addURLMapping(from, to);
-          }
+        for (let [from, to] of urlMappings) {
+          Loader.#instance.addURLMapping(from, to);
         }
-        if (loader) {
-          Loader.#instance.addFileLoader(loader.url, loader.loader);
-        }
+      }
+      if (loader) {
+        Loader.#instance.addFileLoader(loader.url, loader.loader);
       }
     }
     return Loader.#instance;

--- a/runtime-common/loader.ts
+++ b/runtime-common/loader.ts
@@ -144,7 +144,7 @@ export class Loader {
     init?: RequestInit
   ): Promise<Response> {
     if (urlOrRequest instanceof Request) {
-      let request = new Request(this.resolve(urlOrRequest.url), {
+      let request = new Request(this.resolve(urlOrRequest.url).href, {
         method: urlOrRequest.method,
         headers: urlOrRequest.headers,
         body: urlOrRequest.body,

--- a/runtime-common/loader.ts
+++ b/runtime-common/loader.ts
@@ -160,16 +160,6 @@ export class Loader {
     moduleIdentifier: string | URL,
     relativeTo?: URL
   ): ResolvedURL {
-    if (
-      typeof moduleIdentifier === "string" &&
-      !relativeTo &&
-      !moduleIdentifier.startsWith("http")
-    ) {
-      throw new Error(
-        `expected module identifier to be a URL: "${moduleIdentifier}"`
-      );
-    }
-
     let absoluteURL = new URL(moduleIdentifier, relativeTo);
     for (let [paths, to] of this.urlMappings) {
       if (paths.inRealm(absoluteURL)) {
@@ -183,16 +173,6 @@ export class Loader {
     moduleIdentifier: string | ResolvedURL,
     relativeTo?: URL
   ): URL {
-    if (
-      typeof moduleIdentifier === "string" &&
-      !relativeTo &&
-      !moduleIdentifier.startsWith("http")
-    ) {
-      throw new Error(
-        `expected module identifier to be a URL: "${moduleIdentifier}"`
-      );
-    }
-
     let absoluteURL = new URL(moduleIdentifier, relativeTo);
     for (let [sourcePath, to] of this.urlMappings) {
       let destinationPath = new RealmPaths(to);

--- a/runtime-common/realm.ts
+++ b/runtime-common/realm.ts
@@ -71,10 +71,6 @@ export interface RealmAdapter {
   remove(path: LocalPath): Promise<void>;
 }
 
-interface Options {
-  urlMappings?: Map<URL, URL>;
-}
-
 export class Realm {
   #startedUp = new Deferred<void>();
   #searchIndex: SearchIndex;
@@ -88,11 +84,9 @@ export class Realm {
     return this.paths.url;
   }
 
-  constructor(url: string, adapter: RealmAdapter, opts: Options = {}) {
+  constructor(url: string, adapter: RealmAdapter) {
     this.paths = new RealmPaths(url);
-    let { urlMappings = new Map() } = opts;
     this.loader = Loader.getLoader({
-      urlMappings,
       loader: {
         url: new URL(this.url),
         loader: async (url: URL) => {

--- a/runtime-common/realm.ts
+++ b/runtime-common/realm.ts
@@ -86,16 +86,11 @@ export class Realm {
 
   constructor(url: string, adapter: RealmAdapter) {
     this.paths = new RealmPaths(url);
-    let loader = Loader.getLoader({
-      loader: {
-        url: new URL(this.url),
-        loader: async (url: ResolvedURL) => {
-          let content = await this.cardSourceFromResolvedURL(url);
-          return this.transpileJS(content!, url.href);
-        },
-      },
+    Loader.addFileLoader(new URL(this.url), async (url: ResolvedURL) => {
+      let content = await this.cardSourceFromResolvedURL(url);
+      return this.transpileJS(content!, url.href);
     });
-    this.#resolvedPaths = new RealmPaths(loader.resolve(url)); // this is used to work with ResolvedURL's specifically
+    this.#resolvedPaths = new RealmPaths(Loader.resolve(url)); // this is used to work with ResolvedURL's specifically
     this.#adapter = adapter;
     this.#startedUp.fulfill((() => this.#startup())());
     this.#searchIndex = new SearchIndex(
@@ -215,7 +210,7 @@ export class Realm {
       this.paths.local(new URL(request.url)),
       await request.text()
     );
-    Loader.getLoader().clearCache();
+    Loader.clearCache();
     return new Response(null, {
       status: 204,
       headers: {
@@ -266,7 +261,7 @@ export class Realm {
       delete: true,
     });
     await this.#adapter.remove(handle.path);
-    Loader.getLoader().clearCache();
+    Loader.clearCache();
     return new Response(null, { status: 204 });
   }
 

--- a/runtime-common/router.ts
+++ b/runtime-common/router.ts
@@ -1,4 +1,4 @@
-import { methodNotAllowed, notFound } from "./error";
+import { methodNotAllowed, notFound, CardError } from "./error";
 import { RealmPaths } from "./paths";
 
 type Handler = (request: Request) => Promise<Response>;
@@ -66,7 +66,17 @@ export class Router {
       // to make it more readable in our config
       let routeRegExp = new RegExp(`^${route.replace("/", "\\/")}$`);
       if (routeRegExp.test(requestPath)) {
-        return await handler(request);
+        try {
+          return await handler(request);
+        } catch (err) {
+          if (err instanceof CardError) {
+            return err.response;
+          }
+          console.error(err);
+          return new Response(`unexpected exception in service worker ${err}`, {
+            status: 500,
+          });
+        }
       }
     }
     return notFound(request);

--- a/runtime-common/search-index.ts
+++ b/runtime-common/search-index.ts
@@ -231,9 +231,7 @@ export class SearchIndex {
   ) {}
 
   async run() {
-    this.#api = await Loader.getLoader().import<CardAPI>(
-      `${baseRealm.url}card-api`
-    );
+    this.#api = await Loader.import<CardAPI>(`${baseRealm.url}card-api`);
     await this.visitDirectory(new URL(this.realm.url));
     await this.semanticPhase();
   }
@@ -294,7 +292,7 @@ export class SearchIndex {
         } else {
           json.data.id = instanceURL.href;
           json.data.meta.lastModified = lastModified;
-          let module = await Loader.getLoader().import<Record<string, any>>(
+          let module = await Loader.import<Record<string, any>>(
             new URL(
               json.data.meta.adoptsFrom.module,
               new URL(localPath, this.realm.url)
@@ -753,7 +751,7 @@ export class SearchIndex {
     this.#externalDefinitionsCache.set(key, deferred.promise);
 
     let url = `${moduleURL.href}/_typeOf?${stringify(ref)}`;
-    let response = await Loader.getLoader().fetch(url, {
+    let response = await Loader.fetch(url, {
       headers: {
         Accept: "application/vnd.api+json",
       },

--- a/runtime-common/search-index.ts
+++ b/runtime-common/search-index.ts
@@ -231,8 +231,8 @@ export class SearchIndex {
   ) {}
 
   async run() {
-    this.#api = await Loader.getLoader().load<CardAPI>(
-      `${this.realm.baseRealmURL}card-api`
+    this.#api = await Loader.getLoader().import<CardAPI>(
+      `${baseRealm.url}card-api`
     );
     await this.visitDirectory(new URL(this.realm.url));
     await this.semanticPhase();
@@ -294,10 +294,10 @@ export class SearchIndex {
         } else {
           json.data.id = instanceURL.href;
           json.data.meta.lastModified = lastModified;
-          let module = await Loader.getLoader().load<Record<string, any>>(
+          let module = await Loader.getLoader().import<Record<string, any>>(
             new URL(
               json.data.meta.adoptsFrom.module,
-              new URL(localPath, this.realm.hostedAtURL)
+              new URL(localPath, this.realm.url)
             ).href
           );
           let CardClass = module[json.data.meta.adoptsFrom.name] as typeof Card;
@@ -752,11 +752,8 @@ export class SearchIndex {
     let deferred = new Deferred<CardDefinition | undefined>();
     this.#externalDefinitionsCache.set(key, deferred.promise);
 
-    if (baseRealm.inRealm(moduleURL)) {
-      moduleURL = new URL(baseRealm.local(moduleURL), this.realm.baseRealmURL);
-    }
     let url = `${moduleURL.href}/_typeOf?${stringify(ref)}`;
-    let response = await fetch(url, {
+    let response = await Loader.getLoader().fetch(url, {
       headers: {
         Accept: "application/vnd.api+json",
       },

--- a/runtime-common/search-index.ts
+++ b/runtime-common/search-index.ts
@@ -388,7 +388,8 @@ export class SearchIndex {
         refsMap = new Map();
         newExportedCardRefs.set(module, refsMap);
       }
-      refsMap.set(this.internalKeyFor(def.id, undefined), def.id);
+      let { type: remove, ...exportedCardRef } = def.id;
+      refsMap.set(this.internalKeyFor(def.id, undefined), exportedCardRef);
     }
 
     // atomically update the search index

--- a/worker/src/fetch.ts
+++ b/worker/src/fetch.ts
@@ -1,5 +1,6 @@
 import { CardError } from '@cardstack/runtime-common/error';
-import { Realm, baseRealm } from '@cardstack/runtime-common';
+import { Realm } from '@cardstack/runtime-common';
+import { Loader } from '@cardstack/runtime-common/loader';
 
 export class FetchHandler {
   private realm: Realm | undefined;
@@ -22,60 +23,16 @@ export class FetchHandler {
         return await this.dropCaches();
       }
 
-      let urlWithoutQuery = new URL(request.url);
-      // chop off the query string from the URL so we can look at the route specifically
-      urlWithoutQuery = new URL(urlWithoutQuery.pathname, urlWithoutQuery);
-
-      if (baseRealm.inRealm(urlWithoutQuery)) {
-        if (!this.realm) {
-          throw new Error('No realm is currently available');
-        }
-        // translate the request URL into the local base realm URL
-        let url = new URL(
-          request.url.slice(urlWithoutQuery.origin.length),
-          this.realm.baseRealmURL
-        );
-        let response = await fetch(url.href, {
-          method: request.method,
-          headers: request.headers,
-          ...(request.body ? { body: request.body } : {}),
-        });
-        // based on
-        // https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/respondWith#specifying_the_final_url_of_a_resource:
-        //
-        //     "When a service worker provides a Response to
-        //     FetchEvent.respondWith(), the Response.url value will be
-        //     propagated to the intercepted network request as the final
-        //     resolved URL.
-        //
-        //     "This means, for example, if a service worker intercepts a
-        //     stylesheet or worker script, then the provided Response.url will
-        //     be used to resolve any relative @import or importScripts()
-        //     subresource loads (bug 1222008)."
-        //
-        // This means that in order for our module resolution to work using the
-        // canonical base realm URL we need to alter this behavior, otherwise
-        // relative import references will use the wrong origin URL. According
-        // to the same MDN article, a response with an empty string `url`
-        // property will revert to resolving relative references using the
-        // request URL. so we make a new response without a URL value to trigger
-        // that behavior.
-        return new Response(response.body, {
-          status: response.status,
-          statusText: response.statusText,
-          headers: response.headers,
-        });
-      }
       if (!this.realm) {
         console.warn(`No realm is currently available`);
-      } else if (urlWithoutQuery.href.includes(this.realm.url)) {
+      } else if (this.realm.paths.inRealm(new URL(request.url))) {
         return await this.realm.handle(request);
       }
 
       console.log(
         `Service worker passing through ${request.url} for ${request.referrer}`
       );
-      return await fetch(request);
+      return await Loader.fetch(request);
     } catch (err) {
       if (err instanceof CardError) {
         return err.response;

--- a/worker/src/main.ts
+++ b/worker/src/main.ts
@@ -2,7 +2,8 @@ import { FetchHandler } from './fetch';
 import { LivenessWatcher } from './liveness';
 import { MessageHandler } from './message-handler';
 import { LocalRealm } from './local-realm';
-import { Realm } from '@cardstack/runtime-common';
+import { Realm, baseRealm } from '@cardstack/runtime-common';
+import { Loader } from '@cardstack/runtime-common/loader';
 import '@cardstack/runtime-common/externals-global';
 
 const worker = globalThis as unknown as ServiceWorkerGlobalScope;
@@ -15,6 +16,12 @@ livenessWatcher.registerShutdownListener(async () => {
   await fetchHandler.dropCaches();
 });
 
+// This is the locally served base realm
+Loader.addURLMapping(
+  new URL(baseRealm.url),
+  new URL('http://localhost:4201/base/')
+);
+
 // TODO: this should be a more event-driven capability driven from the message
 // handler
 (async () => {
@@ -24,11 +31,7 @@ livenessWatcher.registerShutdownListener(async () => {
       throw new Error(`could not get FileSystem`);
     }
     fetchHandler.addRealm(
-      new Realm(
-        'http://local-realm/',
-        new LocalRealm(messageHandler.fs),
-        { baseRealmURL: 'http://localhost:4201/base/' } // This is the locally served base realm
-      )
+      new Realm('http://local-realm/', new LocalRealm(messageHandler.fs))
     );
   } catch (err) {
     console.log(err);


### PR DESCRIPTION
Refactors the Loader to act as the central point for all fetching, dynamic importing, and resolving in the system. This allows us to centralize all the url mapping logic that has been getting out of hand.