### PR TITLE
Add ability to search based on field card's queryableValue

### DIFF
--- a/base/card-api.gts
+++ b/base/card-api.gts
@@ -154,7 +154,7 @@ export function getQueryableValue(fieldCard: typeof Card, value: any): any {
   
   // this recurses through the fields of the compound card via
   // the base card's queryableValue implementation
-  return (fieldCard as any)[queryableValue](value);
+  return flatten((fieldCard as any)[queryableValue](value));
 }
 
 export function serializedGet<CardT extends CardConstructor>(model: InstanceType<CardT>, fieldName: string ) {
@@ -195,14 +195,7 @@ export function serializeCard<CardT extends CardConstructor>(model: InstanceType
 
 export async function searchDoc<CardT extends CardConstructor>(model: InstanceType<CardT>): Promise<Record<string, any>> {
   await recompute(model);
-
-  let result: Record<string, any> = {};
-  for (let [fieldName, field] of Object.entries(getFields(model))) {
-    let value = getQueryableValue(field.card, model[fieldName as keyof InstanceType<CardT>]);
-    result[fieldName] = value;
-  }
-  let searchDoc = flatten(result);
-  return searchDoc;
+  return getQueryableValue(model.constructor, model) as Record<string, any>;
 }
 
 function flatten(obj: Record<string, any>): Record<string, any> {

--- a/base/card-ref.gts
+++ b/base/card-ref.gts
@@ -1,4 +1,4 @@
-import { Component, primitive, serialize, Card, CardInstanceType, CardConstructor } from './card-api';
+import { Component, primitive, serialize, queryableValue, Card, CardInstanceType, CardConstructor } from './card-api';
 import { ComponentLike } from '@glint/template';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
@@ -44,6 +44,9 @@ export default class CardRefCard extends Card {
   }
   static fromSerialized<T extends CardConstructor>(this: T, cardRef: ExportedCardRef): CardInstanceType<T> {
     return {...cardRef} as CardInstanceType<T>;// return a new object so that the model cannot be mutated from the outside
+  }
+  static [queryableValue](cardRef: ExportedCardRef) {
+    return `${cardRef.module}/${cardRef.name}`; // this assumes the module is an absolute reference
   }
 
   static embedded = class Embedded extends BaseView {}

--- a/base/card-ref.gts
+++ b/base/card-ref.gts
@@ -45,8 +45,11 @@ export default class CardRefCard extends Card {
   static fromSerialized<T extends CardConstructor>(this: T, cardRef: ExportedCardRef): CardInstanceType<T> {
     return {...cardRef} as CardInstanceType<T>;// return a new object so that the model cannot be mutated from the outside
   }
-  static [queryableValue](cardRef: ExportedCardRef) {
-    return `${cardRef.module}/${cardRef.name}`; // this assumes the module is an absolute reference
+  static [queryableValue](cardRef: ExportedCardRef | undefined) {
+    if (cardRef) {
+      return `${cardRef.module}/${cardRef.name}`; // this assumes the module is an absolute reference
+    }
+    return undefined;
   }
 
   static embedded = class Embedded extends BaseView {}

--- a/base/catalog-entry.gts
+++ b/base/catalog-entry.gts
@@ -1,0 +1,23 @@
+import { contains, field, Component, Card } from 'https://cardstack.com/base/card-api';
+import StringCard from 'https://cardstack.com/base/string';
+import CardRefCard from 'https://cardstack.com/base/card-ref';
+
+export class CatalogEntry extends Card {
+  @field title = contains(StringCard);
+  @field description = contains(StringCard);
+  @field ref = contains(CardRefCard);
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <div><@fields.title/></div>
+      <div><@fields.ref/></div>
+    </template>
+  }
+  static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <div><@fields.title/></div>
+      <div><@fields.description/></div>
+      <div><@fields.ref/></div>
+    </template>
+  }
+}

--- a/base/date.gts
+++ b/base/date.gts
@@ -1,4 +1,4 @@
-import { Component, primitive, serialize, Card, CardInstanceType, CardConstructor } from './card-api';
+import { Component, primitive, serialize, queryableValue, Card, CardInstanceType, CardConstructor } from './card-api';
 import { parse, format } from 'date-fns';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
@@ -12,17 +12,26 @@ const Format = new Intl.DateTimeFormat('us-EN', {
   day: 'numeric',
 });
 
+const dateFormat = `yyyy-MM-dd`;
+
 export default class DateCard extends Card {
   static [primitive]: Date;
   static [serialize](date: string | Date) {
     if (typeof date === 'string') {
       return date;
     }
-    return format(date, 'yyyy-MM-dd');
+    return format(date, dateFormat);
   }
 
   static fromSerialized<T extends CardConstructor>(this: T, date: any): CardInstanceType<T> {
-    return parse(date, 'yyyy-MM-dd', new Date()) as CardInstanceType<T>;
+    return parse(date, dateFormat, new Date()) as CardInstanceType<T>;
+  }
+
+  static [queryableValue](date: Date | undefined) {
+    if (date) {
+      return format(date, dateFormat);
+    }
+    return undefined;
   }
 
   static embedded = class Embedded extends Component<typeof this> {

--- a/base/datetime.gts
+++ b/base/datetime.gts
@@ -1,4 +1,4 @@
-import { Component, primitive, serialize, CardInstanceType, CardConstructor, Card } from './card-api';
+import { Component, primitive, serialize, queryableValue, CardInstanceType, CardConstructor, Card } from './card-api';
 import { format, parseISO } from 'date-fns';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
@@ -15,6 +15,8 @@ const Format = new Intl.DateTimeFormat('us-EN', {
   minute: '2-digit',
 });
 
+const datetimeFormat = `yyyy-MM-dd'T'HH:mm`;
+
 export default class DatetimeCard extends Card {
   static [primitive]: Date;
   static [serialize](date: string | Date) {
@@ -26,6 +28,13 @@ export default class DatetimeCard extends Card {
 
   static fromSerialized<T extends CardConstructor>(this: T, date: any): CardInstanceType<T> {
     return parseISO(date) as CardInstanceType<T>;
+  }
+
+  static [queryableValue](date: Date | undefined) {
+    if (date) {
+      return format(date, datetimeFormat);
+    }
+    return undefined;
   }
 
   static embedded = class Embedded extends Component<typeof this> {
@@ -53,7 +62,7 @@ export default class DatetimeCard extends Card {
       if (!this.args.model) {
         return;
       }
-      return format(this.args.model, `yyyy-MM-dd'T'HH:mm`);
+      return format(this.args.model, datetimeFormat);
     }
   }
 }

--- a/host/tests/cards/dog.gts
+++ b/host/tests/cards/dog.gts
@@ -1,0 +1,8 @@
+import { contains, field, Card } from "https://cardstack.com/base/card-api";
+import StringCard from "https://cardstack.com/base/string";
+import SillyNumberCard from "./silly-number";
+
+export class Dog extends Card {
+  @field firstName = contains(StringCard);
+  @field numberOfTreats = contains(SillyNumberCard);
+}

--- a/host/tests/cards/silly-number.gts
+++ b/host/tests/cards/silly-number.gts
@@ -1,0 +1,51 @@
+import { Component, Card, queryableValue, primitive } from "https://cardstack.com/base/card-api";
+
+class View extends Component<typeof SillyNumberCard> {
+  <template>{{this.value}}</template>
+  get value() {
+    if (this.args.model == null) {
+      return "";
+    }
+    return this.args.model.join(' ');
+  }
+}
+
+export default class SillyNumberCard extends Card {
+  static [primitive]: string[];
+  static [queryableValue](value: string[] | undefined) {
+    if (!value) {
+      return undefined;
+    }
+    let result = value.map(word => {
+      switch(word) {
+        case 'zero' :
+          return '0';
+        case 'one' :
+          return '1';
+        case 'two' :
+          return '2';
+        case 'three' :
+          return '3';
+        case 'four' :
+          return '4';
+        case 'five' :
+          return '5';
+        case 'six' :
+          return '6';
+        case 'seven' :
+          return '7';
+        case 'eight' :
+          return '8';
+        case 'nine' :
+          return '9';
+        default :
+         return '0';
+      }
+    });
+    return parseInt(result.join(''));
+  }
+
+  static embedded = View;
+  static isolated = View;
+  static edit = View;
+}

--- a/host/tests/integration/components/card-basics-test.gts
+++ b/host/tests/integration/components/card-basics-test.gts
@@ -725,18 +725,6 @@ module('Integration | card-basics', function (hooks) {
     assert.strictEqual(getQueryableValue(StringCard, 'Van Gogh'), 'Van Gogh', 'The queryable value from user supplied data is correct')
   });
 
-  test('throws when attempting to get a queryable value for a non-primitive field', async function (assert) {
-    let { field, contains, Card, getQueryableValue } = cardApi;
-    let { default: StringCard} = string;
-
-    class CompoundField extends Card {
-      @field firstName = contains(StringCard);
-      @field lastName = contains(StringCard);
-    }
-
-    assert.throws(() => getQueryableValue(CompoundField, { firstName: 'Mango', lastName: 'Abdel-Rahman'}), /cannot getQueryableValue for non-primitive field/);
-  });
-
   test('throws when card returns non-scalar queryable value from "queryableValue" function', async function (assert) {
     let { Card, getQueryableValue } = cardApi;
 
@@ -746,7 +734,7 @@ module('Integration | card-basics', function (hooks) {
         return { notAScalar: true };
       }
     }
-    assert.throws(() => getQueryableValue(TestField1, { firstName: 'Mango', lastName: 'Abdel-Rahman'}), /expected value to be scalar/);
+    assert.throws(() => getQueryableValue(TestField1, { firstName: 'Mango', lastName: 'Abdel-Rahman'}), /expected queryableValue for field type TestField1 to be scalar/);
 
     class TestField2 extends Card {
       static [primitive]: TestShape;
@@ -754,7 +742,7 @@ module('Integration | card-basics', function (hooks) {
         return [{ notAScalar: true }];
       }
     }
-    assert.throws(() => getQueryableValue(TestField2, { firstName: 'Mango', lastName: 'Abdel-Rahman'}), /expected value to be scalar/);
+    assert.throws(() => getQueryableValue(TestField2, { firstName: 'Mango', lastName: 'Abdel-Rahman'}), /expected queryableValue for field type TestField2 to be scalar/);
   })
 
   test('throws when card returns non-scalar queryable value when there is no "queryableValue" function', async function (assert) {
@@ -763,7 +751,7 @@ module('Integration | card-basics', function (hooks) {
     class TestField extends Card {
       static [primitive]: TestShape;
     }
-    assert.throws(() => getQueryableValue(TestField, { firstName: 'Mango', lastName: 'Abdel-Rahman'}), /expected value to be scalar/);
+    assert.throws(() => getQueryableValue(TestField, { firstName: 'Mango', lastName: 'Abdel-Rahman'}), /expected queryableValue for field type TestField to be scalar/);
   })
 });
 

--- a/host/tests/unit/search-index-test.ts
+++ b/host/tests/unit/search-index-test.ts
@@ -2,6 +2,7 @@ import { module, test, skip } from 'qunit';
 import { TestRealm, TestRealmAdapter, testRealmURL } from '../helpers';
 import { RealmPaths } from '@cardstack/runtime-common/paths';
 import { SearchIndex } from '@cardstack/runtime-common/search-index';
+import { baseRealm } from '@cardstack/runtime-common';
 
 let paths = new RealmPaths(testRealmURL);
 
@@ -707,6 +708,44 @@ posts/ignore-me.gts
           },
         },
       },
+      'catalog-entry-1.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            title: 'Post',
+            description: 'A card that represents a blog post',
+            ref: {
+              module: `${testModuleRealm}post`,
+              name: 'Post',
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${baseRealm.url}catalog-entry`,
+              name: 'CatalogEntry',
+            },
+          },
+        },
+      },
+      'catalog-entry-2.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            title: 'Article',
+            description: 'A card that represents an online article ',
+            ref: {
+              module: `${testModuleRealm}article`,
+              name: 'Article',
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${baseRealm.url}catalog-entry`,
+              name: 'CatalogEntry',
+            },
+          },
+        },
+      },
     };
 
     let indexer: SearchIndex;
@@ -740,6 +779,24 @@ posts/ignore-me.gts
       assert.deepEqual(
         matching.map((m) => m.id),
         [`${paths.url}cards/1`]
+      );
+    });
+
+    test(`can search for cards that have custom queryableValue`, async function (assert) {
+      let matching = await indexer.search({
+        filter: {
+          on: { module: `${baseRealm.url}catalog-entry`, name: 'CatalogEntry' },
+          eq: {
+            ref: {
+              module: `${testModuleRealm}post`,
+              name: 'Post',
+            },
+          },
+        },
+      });
+      assert.deepEqual(
+        matching.map((m) => m.id),
+        [`${paths.url}catalog-entry-1`]
       );
     });
 

--- a/host/tests/unit/search-index-test.ts
+++ b/host/tests/unit/search-index-test.ts
@@ -782,6 +782,51 @@ posts/ignore-me.gts
           },
         },
       },
+      'mango.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            firstName: 'Mango',
+            numberOfTreats: ['one', 'two'],
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testModuleRealm}dog`,
+              name: 'Dog',
+            },
+          },
+        },
+      },
+      'ringo.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            firstName: 'Ringo',
+            numberOfTreats: ['three', 'five'],
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testModuleRealm}dog`,
+              name: 'Dog',
+            },
+          },
+        },
+      },
+      'vangogh.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            firstName: 'Van Gogh',
+            numberOfTreats: ['two', 'nine'],
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testModuleRealm}dog`,
+              name: 'Dog',
+            },
+          },
+        },
+      },
     };
 
     let indexer: SearchIndex;
@@ -914,6 +959,21 @@ posts/ignore-me.gts
       );
     });
 
+    test('can use a range filter with custom queryableValue', async function (assert) {
+      let matching = await indexer.search({
+        filter: {
+          on: { module: `${testModuleRealm}dog`, name: 'Dog' },
+          range: {
+            numberOfTreats: { lt: ['three', 'zero'], gt: ['two', 'zero'] },
+          },
+        },
+      });
+      assert.deepEqual(
+        matching.map((m) => m.id),
+        [`${paths.url}vangogh`]
+      );
+    });
+
     test(`gives a good error when query refers to missing card`, async function (assert) {
       try {
         await indexer.search({
@@ -1037,6 +1097,27 @@ posts/ignore-me.gts
           `${paths.url}cards/1`, // type is post
           `${paths.url}cards/2`, // Carl
           `${paths.url}card-1`, // Cardy
+        ]
+      );
+    });
+
+    test('can sort by custom queryableValue', async function (assert) {
+      let matching = await indexer.search({
+        sort: [
+          {
+            by: 'numberOfTreats',
+            on: { module: `${testModuleRealm}dog`, name: 'Dog' },
+            direction: 'asc',
+          },
+        ],
+        filter: { type: { module: `${testModuleRealm}dog`, name: 'Dog' } },
+      });
+      assert.deepEqual(
+        matching.map((m) => m.id),
+        [
+          `${paths.url}mango`, // 12
+          `${paths.url}vangogh`, // 29
+          `${paths.url}ringo`, // 35
         ]
       );
     });

--- a/runtime-common/query.ts
+++ b/runtime-common/query.ts
@@ -58,10 +58,12 @@ export interface EqFilter extends TypedFilter {
 export interface RangeFilter extends TypedFilter {
   range: {
     [fieldName: string]: {
-      gt?: JSON.Primitive;
-      gte?: JSON.Primitive;
-      lt?: JSON.Primitive;
-      lte?: JSON.Primitive;
+      // these might be objects that have custom queryable values so we need to
+      // be permissive on the types
+      gt?: JSON.Value;
+      gte?: JSON.Value;
+      lt?: JSON.Value;
+      lte?: JSON.Value;
     };
   };
 }

--- a/runtime-common/search-index.ts
+++ b/runtime-common/search-index.ts
@@ -717,7 +717,6 @@ export class SearchIndex {
         if (b === undefined) {
           return direction === "desc" ? 1 : -1; // `a` is not null
         }
-        // TODO: use queryableValue check here
         if (a < b) {
           return direction === "desc" ? 1 : -1;
         } else if (a > b) {
@@ -841,10 +840,26 @@ export class SearchIndex {
             }
 
             if (
-              (range.gt && !(value > range.gt)) ||
-              (range.lt && !(value < range.lt)) ||
-              (range.gte && !(value >= range.gte)) ||
-              (range.lte && !(value <= range.lte))
+              (range.gt &&
+                !(
+                  value >
+                  this.api.getQueryableValue(fieldCards[fieldPath]!, range.gt)
+                )) ||
+              (range.lt &&
+                !(
+                  value <
+                  this.api.getQueryableValue(fieldCards[fieldPath]!, range.lt)
+                )) ||
+              (range.gte &&
+                !(
+                  value >=
+                  this.api.getQueryableValue(fieldCards[fieldPath]!, range.gte)
+                )) ||
+              (range.lte &&
+                !(
+                  value <=
+                  this.api.getQueryableValue(fieldCards[fieldPath]!, range.lte)
+                ))
             ) {
               return false;
             }


### PR DESCRIPTION
This PR adds the ability to search based on a field card's queryableValue. This PR introduces the `catalog-entry` base card which includes a `CardRef` field, that in turn has a custom `queryableValue` defined. When the search doc for cards is created, we'll use the `queryableValue` to construct the fields in the search doc. This PR additionally loads all the field cards that are part of a query and uses uses `queryableValue` on the user supplied search predicate from the related field card. 

Interestingly, the act of loading field cards for all the fields in the search query actually has the side effect of validating the fields--as such I removed that function and just replaced it with a field card loading mechanism which performs the validation as part of loading the field cards.