### PR TITLE
Updated to make createFromSerialized() async 

### DIFF
--- a/base/card-ref.gts
+++ b/base/card-ref.gts
@@ -1,4 +1,4 @@
-import { Component, primitive, serialize, queryableValue, Card, CardInstanceType, CardConstructor } from './card-api';
+import { Component, primitive, serialize, deserialize, queryableValue, Card, CardConstructor, CardInstanceType, createFromSerialized } from './card-api';
 import { ComponentLike } from '@glint/template';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
@@ -34,7 +34,7 @@ class BaseView extends Component<typeof CardRefCard> {
     }
     let module: Record<string, any> = await Loader.import(this.args.model.module);
     let Clazz: typeof Card = module[this.args.model.name];
-    this.card = Clazz.fromSerialized({...(Clazz as any).demo ?? {}});
+    this.card = await createFromSerialized(Clazz, {...(Clazz as any).demo ?? {}});
   }
 }
 
@@ -44,7 +44,7 @@ export default class CardRefCard extends Card {
   static [serialize](cardRef: ExportedCardRef) {
     return {...cardRef}; // return a new object so that the model cannot be mutated from the outside
   }
-  static fromSerialized<T extends CardConstructor>(this: T, cardRef: ExportedCardRef): CardInstanceType<T> {
+  static async [deserialize]<T extends CardConstructor>(this: T, cardRef: ExportedCardRef): Promise<CardInstanceType<T>> {
     return {...cardRef} as CardInstanceType<T>;// return a new object so that the model cannot be mutated from the outside
   }
   static [queryableValue](cardRef: ExportedCardRef | undefined) {

--- a/base/date.gts
+++ b/base/date.gts
@@ -1,4 +1,4 @@
-import { Component, primitive, serialize, queryableValue, Card, CardInstanceType, CardConstructor } from './card-api';
+import { Component, primitive, serialize, deserialize, queryableValue, Card, CardInstanceType, CardConstructor } from './card-api';
 import { parse, format } from 'date-fns';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
@@ -23,7 +23,7 @@ export default class DateCard extends Card {
     return format(date, dateFormat);
   }
 
-  static fromSerialized<T extends CardConstructor>(this: T, date: any): CardInstanceType<T> {
+  static async [deserialize]<T extends CardConstructor>(this: T, date: any): Promise<CardInstanceType<T>> {
     return parse(date, dateFormat, new Date()) as CardInstanceType<T>;
   }
 
@@ -51,8 +51,7 @@ export default class DateCard extends Card {
     </template>
 
     parseInput(set: Function, date: string) {
-      let deserialized = DateCard.fromSerialized(date);
-      return set(deserialized);
+      return set(parse(date, dateFormat, new Date()));
     }
 
     get formatted() {

--- a/base/datetime.gts
+++ b/base/datetime.gts
@@ -1,4 +1,4 @@
-import { Component, primitive, serialize, queryableValue, CardInstanceType, CardConstructor, Card } from './card-api';
+import { Component, primitive, serialize, deserialize, queryableValue, CardInstanceType, CardConstructor, Card } from './card-api';
 import { format, parseISO } from 'date-fns';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
@@ -26,7 +26,7 @@ export default class DatetimeCard extends Card {
     return date.toISOString();
   }
 
-  static fromSerialized<T extends CardConstructor>(this: T, date: any): CardInstanceType<T> {
+  static async [deserialize]<T extends CardConstructor>(this: T, date: any): Promise<CardInstanceType<T>> {
     return parseISO(date) as CardInstanceType<T>;
   }
 
@@ -54,8 +54,7 @@ export default class DatetimeCard extends Card {
     </template>
 
     parseInput(set: Function, date: string) {
-      let deserialized = DatetimeCard.fromSerialized(date);
-      return set(deserialized);
+      return set(parseISO(date));
     }
 
     get formatted() {

--- a/host/app/resources/card-instance.ts
+++ b/host/app/resources/card-instance.ts
@@ -1,0 +1,44 @@
+import { Resource, useResource } from 'ember-resources';
+import { restartableTask } from 'ember-concurrency';
+import { taskFor } from 'ember-concurrency-ts';
+import { tracked } from '@glimmer/tracking';
+import { Loader } from '@cardstack/runtime-common/loader';
+import type { Card } from 'https://cardstack.com/base/card-api';
+
+interface Args {
+  named: {
+    CardClass: typeof Card | undefined;
+    serializedData: any;
+  };
+}
+
+export class CardInstance extends Resource<Args> {
+  @tracked instance: Card | undefined;
+
+  constructor(owner: unknown, args: Args) {
+    super(owner, args);
+
+    let { CardClass, serializedData } = args.named;
+    if (CardClass !== undefined) {
+      taskFor(this.createCard).perform(CardClass, serializedData);
+    }
+  }
+
+  @restartableTask private async createCard(CardClass: typeof Card, data: any) {
+    let api = await Loader.import<
+      typeof import('https://cardstack.com/base/card-api')
+    >('https://cardstack.com/base/card-api');
+    let instance = await api.createFromSerialized(CardClass, data);
+    this.instance = instance;
+  }
+}
+
+export function cardInstance(
+  parent: object,
+  CardClass: () => typeof Card | undefined,
+  serializedData: () => any
+) {
+  return useResource(parent, CardInstance, () => ({
+    named: { CardClass: CardClass(), serializedData: serializedData() },
+  }));
+}

--- a/host/tests/integration/components/computed-test.gts
+++ b/host/tests/integration/components/computed-test.gts
@@ -62,7 +62,7 @@ module('Integration | computeds', function (hooks) {
   });
 
   test('can render a computed that consumes a nested property', async function(assert) {
-    let { field, contains, Card, Component } = cardApi;
+    let { field, contains, Card, Component, createFromSerialized } = cardApi;
     let { default: StringCard} = string;
     class Person extends Card {
       @field firstName = contains(StringCard);
@@ -77,7 +77,7 @@ module('Integration | computeds', function (hooks) {
       }
     }
 
-    let firstPost = Post.fromSerialized({ title: 'First Post', author: { firstName: 'Mango' } });
+    let firstPost = await createFromSerialized(Post, { title: 'First Post', author: { firstName: 'Mango' } });
     await renderCard(firstPost, 'isolated');
     assert.strictEqual(this.element.textContent!.trim(), 'First Post by Mango');
   });
@@ -171,7 +171,7 @@ module('Integration | computeds', function (hooks) {
   });
 
   test('can render a nested asynchronous computed field', async function(assert) {
-    let { field, contains, Card, Component } = cardApi;
+    let { field, contains, Card, Component, createFromSerialized } = cardApi;
     let { default: StringCard} = string;
     class Person extends Card {
       @field firstName = contains(StringCard);
@@ -190,7 +190,7 @@ module('Integration | computeds', function (hooks) {
       }
     }
 
-    let firstPost = Post.fromSerialized({ title: 'First Post', author: { firstName: 'Mango' } });
+    let firstPost = await createFromSerialized(Post, { title: 'First Post', author: { firstName: 'Mango' } });
     await renderCard(firstPost, 'isolated');
     assert.strictEqual(cleanWhiteSpace(this.element.textContent!), 'First Post by Mango');
   });
@@ -270,7 +270,7 @@ module('Integration | computeds', function (hooks) {
   });
 
   test('can render a containsMany computed composite field', async function(assert) {
-    let { field, contains, containsMany, Card, Component } = cardApi;
+    let { field, contains, containsMany, Card, Component, createFromSerialized } = cardApi;
     let { default: StringCard} = string;
     class Person extends Card {
       @field firstName = contains(StringCard);
@@ -290,7 +290,7 @@ module('Integration | computeds', function (hooks) {
         <template><@fields.slowPeople/></template>
       }
     }
-    let abdelRahmans = Family.fromSerialized({
+    let abdelRahmans = await createFromSerialized(Family, {
       people: [
         { firstName: 'Mango'},
         { firstName: 'Van Gogh'},
@@ -346,7 +346,7 @@ module('Integration | computeds', function (hooks) {
   });
 
   test('can maintain data consistency for async computed fields', async function(assert) {
-    let { field, contains, Card, Component } = cardApi;
+    let { field, contains, Card, Component, createFromSerialized } = cardApi;
     let { default: StringCard} = string;
     class Location extends Card {
       @field city = contains(StringCard);
@@ -379,7 +379,7 @@ module('Integration | computeds', function (hooks) {
       }
     }
 
-    let person = Person.fromSerialized({ firstName: 'Mango', homeTown: { city: 'Bronxville' } });
+    let person = await createFromSerialized(Person, { firstName: 'Mango', homeTown: { city: 'Bronxville' } });
 
 
     await renderCard(person, 'edit');

--- a/host/tests/integration/components/preview-test.gts
+++ b/host/tests/integration/components/preview-test.gts
@@ -12,7 +12,7 @@ let cardApi: typeof import("https://cardstack.com/base/card-api");
 let string: typeof import ("https://cardstack.com/base/string");
 
 const formats: Format[] = ['isolated', 'embedded', 'edit'];
-module('Integration | card-editor', function (hooks) {
+module('Integration | preview', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.before(async function () {

--- a/host/tests/integration/components/serialization-test.gts
+++ b/host/tests/integration/components/serialization-test.gts
@@ -458,7 +458,7 @@ module('Integration | serialization', function (hooks) {
   });
 
   test('can serialize a card whose composite field value uses a card that adopts from the composite field card', async function (assert) {
-    let { field, contains, serializeCard, Card, } = cardApi;
+    let { field, contains, serializeCard, Card, createFromSerialized } = cardApi;
     let { default: StringCard } = string;
     let { default: DateCard } = date;
 
@@ -499,7 +499,7 @@ module('Integration | serialization', function (hooks) {
       }
     );
 
-    let post2 = Post.fromSerialized(payload.attributes); // success is not blowing up
+    let post2 = await createFromSerialized(Post, payload.attributes); // success is not blowing up
     assert.strictEqual(post2.author.firstName, 'Mango');
   });
 

--- a/host/tests/integration/components/serialization-test.gts
+++ b/host/tests/integration/components/serialization-test.gts
@@ -33,7 +33,7 @@ module('Integration | serialization', function (hooks) {
   });
 
   test('can deserialize field', async function (assert) {
-    let { field, contains, Card, Component } = cardApi;
+    let { field, contains, Card, Component, createFromSerialized } = cardApi;
     let { default: StringCard } = string;
     let { default: DateCard } = date;
     let { default: DatetimeCard } = datetime;
@@ -47,7 +47,7 @@ module('Integration | serialization', function (hooks) {
     }
 
     // initialize card data as serialized to force us to deserialize instead of using cached data
-    let firstPost = Post.fromSerialized({ title: 'First Post', created: '2022-04-22', published: '2022-04-27T16:02' });
+    let firstPost = await createFromSerialized(Post, { title: 'First Post', created: '2022-04-22', published: '2022-04-27T16:02' });
     await renderCard(firstPost, 'isolated');
 
     // the template value 'Apr 22, 2022' can only be realized when the card has
@@ -56,7 +56,7 @@ module('Integration | serialization', function (hooks) {
   });
 
   test('deserialized card ref fields are not strict equal to serialized card ref', async function(assert) {
-    let {field, contains, Card, Component } = cardApi;
+    let {field, contains, Card, Component, createFromSerialized } = cardApi;
     let { default: CardRefCard } = cardRef;
     class DriverCard extends Card {
       @field ref = contains(CardRefCard);
@@ -66,7 +66,7 @@ module('Integration | serialization', function (hooks) {
     }
 
     let ref = { module: `http://localhost:4201/test/person`, name: 'Person' };
-    let driver = DriverCard.fromSerialized({ ref });
+    let driver = await createFromSerialized(DriverCard, { ref });
     assert.ok(driver.ref !== ref, 'the card ref value is not strict equals to its serialized counter part');
     assert.deepEqual(driver.ref, ref, 'the card ref value is deep equal to its serialized counter part')
   });
@@ -109,7 +109,7 @@ module('Integration | serialization', function (hooks) {
   });
 
   test('can deserialize a date field with null value', async function (assert) {
-    let { field, contains, Card, Component } = cardApi;
+    let { field, contains, Card, Component, createFromSerialized } = cardApi;
     let { default: StringCard } = string;
     let { default: DateCard } = date;
     let { default: DatetimeCard } = datetime;
@@ -122,7 +122,7 @@ module('Integration | serialization', function (hooks) {
       }
     }
 
-    let firstPost = Post.fromSerialized({ title: 'First Post', created: null, published: null });
+    let firstPost = await createFromSerialized(Post, { title: 'First Post', created: null, published: null });
     await renderCard(firstPost, 'isolated');
     assert.strictEqual(cleanWhiteSpace(this.element.textContent!), 'First Post created [no date] published [no date-time]');
   });
@@ -154,7 +154,7 @@ module('Integration | serialization', function (hooks) {
   });
 
   test('can deserialize a nested field', async function(assert) {
-    let { field, contains, Card, Component } = cardApi;
+    let { field, contains, Card, Component, createFromSerialized } = cardApi;
     let { default: StringCard } = string;
     let { default: DateCard } = date;
     let { default: DatetimeCard } = datetime;
@@ -172,13 +172,13 @@ module('Integration | serialization', function (hooks) {
       }
     }
 
-    let firstPost = Post.fromSerialized({ title: 'First Post', author: { firstName: 'Mango', birthdate: '2019-10-30', lastLogin: '2022-04-27T16:58' } });
+    let firstPost = await createFromSerialized(Post, { title: 'First Post', author: { firstName: 'Mango', birthdate: '2019-10-30', lastLogin: '2022-04-27T16:58' } });
     await renderCard(firstPost, 'isolated');
     assert.strictEqual(cleanWhiteSpace(this.element.textContent!), 'birthdate Oct 30, 2019 last login Apr 27, 2022, 4:58 PM');
   });
 
   test('can deserialize a composite field', async function(assert) {
-    let { field, contains, Card, Component } = cardApi;
+    let { field, contains, Card, Component, createFromSerialized } = cardApi;
     let { default: StringCard } = string;
     let { default: DateCard } = date;
     let { default: DatetimeCard } = datetime;
@@ -199,7 +199,7 @@ module('Integration | serialization', function (hooks) {
       }
     }
 
-    let firstPost = Post.fromSerialized({ title: 'First Post', author: { firstName: 'Mango', birthdate: '2019-10-30', lastLogin: '2022-04-27T17:00' } });
+    let firstPost = await createFromSerialized(Post, { title: 'First Post', author: { firstName: 'Mango', birthdate: '2019-10-30', lastLogin: '2022-04-27T17:00' } });
     await renderCard(firstPost, 'isolated');
     assert.strictEqual(cleanWhiteSpace(this.element.textContent!), 'Mango born on: Oct 30, 2019 last logged in: Apr 27, 2022, 5:00 PM');
   });
@@ -246,7 +246,7 @@ module('Integration | serialization', function (hooks) {
   });
 
   test('can serialize a composite field that has been edited', async function(assert) {
-    let { field, contains, serializeCard, Card, Component } = cardApi;
+    let { field, contains, serializeCard, Card, Component, createFromSerialized } = cardApi;
     let { default: StringCard } = string;
     let { default: IntegerCard} = integer;
     class Person extends Card {
@@ -275,7 +275,7 @@ module('Integration | serialization', function (hooks) {
       }
     }
 
-    let helloWorld = Post.fromSerialized({ title: 'First Post', reviews: 1, author: { firstName: 'Arthur' } });
+    let helloWorld = await createFromSerialized(Post, { title: 'First Post', reviews: 1, author: { firstName: 'Arthur' } });
     await renderCard(helloWorld, 'edit');
     await fillIn('[data-test-field="author"] input', 'Carl Stack');
 
@@ -312,7 +312,7 @@ module('Integration | serialization', function (hooks) {
   });
 
   test('can deserialize a containsMany field', async function(assert) {
-    let { field, containsMany, Card, Component } = cardApi;
+    let { field, containsMany, Card, Component, createFromSerialized } = cardApi;
     let { default: DateCard } = date;
     class Schedule extends Card {
       @field dates = containsMany(DateCard);
@@ -321,13 +321,13 @@ module('Integration | serialization', function (hooks) {
       }
     }
 
-    let classSchedule = Schedule.fromSerialized({ dates: ['2022-4-1', '2022-4-4'] });
+    let classSchedule = await createFromSerialized(Schedule, { dates: ['2022-4-1', '2022-4-4'] });
     await renderCard(classSchedule, 'isolated');
     assert.strictEqual(cleanWhiteSpace(this.element.textContent!), 'Apr 1, 2022 Apr 4, 2022');
   });
 
   test("can deserialize a containsMany's nested field", async function(assert) {
-    let { field, contains, containsMany, Card, Component } = cardApi;
+    let { field, contains, containsMany, Card, Component, createFromSerialized } = cardApi;
     let { default: StringCard } = string;
     let { default: DateCard } = date;
     class Appointment extends Card {
@@ -344,7 +344,7 @@ module('Integration | serialization', function (hooks) {
         <template><@fields.appointments/></template>
       }
     }
-    let classSchedule = Schedule.fromSerialized({ appointments: [
+    let classSchedule = await createFromSerialized(Schedule, { appointments: [
       { date: '2022-4-1', location: 'Room 332', title: 'Biology' },
       { date: '2022-4-4', location: 'Room 102', title: 'Civics' }
     ]});

--- a/realm-server/tests/realm-server-test.ts
+++ b/realm-server/tests/realm-server-test.ts
@@ -447,32 +447,35 @@ module("Realm Server", function (hooks) {
 
   test("can dynamically load a card from own realm", async function (assert) {
     let loader = Loader.createLoaderFromGlobal();
+    let api = await loader.import<any>("https://cardstack.com/base/card-api");
     let module = await loader.import<Record<string, any>>(
       `${testRealmHref}person`
     );
     let Person = module["Person"];
-    let person = Person.fromSerialized({ firstName: "Mango" });
+    let person = await api.createFromSerialized(Person, { firstName: "Mango" });
     assert.strictEqual(person.firstName, "Mango", "card data is correct");
   });
 
   test("can dynamically load a card from a different realm", async function (assert) {
     let loader = Loader.createLoaderFromGlobal();
+    let api = await loader.import<any>("https://cardstack.com/base/card-api");
     let module = await loader.import<Record<string, any>>(
       `${testRealm2Href}person`
     );
     let Person = module["Person"];
-    let person = Person.fromSerialized({ firstName: "Mango" });
+    let person = await api.createFromSerialized(Person, { firstName: "Mango" });
     assert.strictEqual(person.firstName, "Mango", "card data is correct");
   });
 
   test("can instantiate a card that uses a card-ref field", async function (assert) {
     let loader = Loader.createLoaderFromGlobal();
+    let api = await loader.import<any>("https://cardstack.com/base/card-api");
     let module = await loader.import<Record<string, any>>(
       `${testRealm2Href}card-ref-test`
     );
     let TestCard = module["TestCard"];
-    let ref = { module: `${testRealm2Href}person`, name: "Person " };
-    let testCard = TestCard.fromSerialized({ ref });
+    let ref = { module: `${testRealm2Href}person`, name: "Person" };
+    let testCard = await api.createFromSerialized(TestCard, { ref });
     assert.deepEqual(testCard.ref, ref, "card data is correct");
   });
 });

--- a/runtime-common/current-run.ts
+++ b/runtime-common/current-run.ts
@@ -419,10 +419,13 @@ export class CurrentRun {
       let doc: CardDocument | undefined;
       let searchData: any;
       try {
-        let CardClass = module[name] as typeof Card;
-        let card = CardClass.fromSerialized(json.data.attributes);
         let api = await this.#loader.import<CardAPI>(
           `${baseRealm.url}card-api`
+        );
+        let CardClass = module[name] as typeof Card;
+        let card = await api.createFromSerialized(
+          CardClass,
+          json.data.attributes
         );
         await api.recompute(card);
         let data = api.serializeCard(card, {

--- a/runtime-common/realm.ts
+++ b/runtime-common/realm.ts
@@ -786,7 +786,10 @@ export class Realm {
       new URL(json.data.meta.adoptsFrom.module, relativeTo).href
     );
     let CardClass = module[json.data.meta.adoptsFrom.name] as CardAPI["Card"];
-    let card = CardClass.fromSerialized(json.data.attributes ?? {});
+    let card = await api.createFromSerialized(
+      CardClass,
+      json.data.attributes ?? {}
+    );
     let data = {
       data: api.serializeCard(card, { adoptsFrom: json.data.meta.adoptsFrom }),
     }; // this strips out computeds


### PR DESCRIPTION
To create a card from serialized data now looks like this:

```js
import { createFromSerialized } from "https://cardstack.com/base/card-api";
import PersonCard from "./person";

.
.
let person = await createFromSerialized(PersonCard, { firstName: "Mango", lastName: "Abdel-Rahman" });
```