### PR TITLE
Refactor indexing to make use of card executables vs module analysis

### DIFF
--- a/base/card-api.gts
+++ b/base/card-api.gts
@@ -49,6 +49,8 @@ interface Field<CardT extends CardConstructor> {
   card: CardT;
   name: string;
   computeVia: undefined | string | (() => unknown);
+  // TODO once we add linksTo, we'll probably want a better property here, maybe:
+  // fieldType: "contains" | "containsMany" | "linksTo" | "linksToMany"
   containsMany: boolean;
   serialize(value: any): any;
   deserialize(value: any, fromResource: LooseCardResource | undefined, instancePromise: Promise<Card>): Promise<any>;
@@ -640,7 +642,7 @@ async function loadField<T extends Card, K extends keyof T>(model: T, fieldName:
   return result!;
 }
 
-function getField<CardT extends CardConstructor>(card: CardT, fieldName: string): Field<CardConstructor> | undefined {
+export function getField<CardT extends CardConstructor>(card: CardT, fieldName: string): Field<CardConstructor> | undefined {
   let obj: object | null = card.prototype;
   while (obj) {
     let desc = Reflect.getOwnPropertyDescriptor(obj, fieldName);
@@ -653,9 +655,9 @@ function getField<CardT extends CardConstructor>(card: CardT, fieldName: string)
   return undefined;
 }
 
-function getFields(card: typeof Card, opts?: { includeComputeds?: boolean }): { [fieldName: string]: Field<CardConstructor> };
-function getFields<T extends Card>(card: T, opts?: { includeComputeds?: boolean }): { [P in keyof T]?: Field<CardConstructor> };
-function getFields(cardInstanceOrClass: Card | typeof Card, opts?: { includeComputeds?: boolean }): { [fieldName: string]: Field<CardConstructor> } {
+export function getFields(card: typeof Card, opts?: { includeComputeds?: boolean }): { [fieldName: string]: Field<CardConstructor> };
+export function getFields<T extends Card>(card: T, opts?: { includeComputeds?: boolean }): { [P in keyof T]?: Field<CardConstructor> };
+export function getFields(cardInstanceOrClass: Card | typeof Card, opts?: { includeComputeds?: boolean }): { [fieldName: string]: Field<CardConstructor> } {
   let obj: object | null;
   if (isBaseCard in cardInstanceOrClass) {
     // this is a card instance

--- a/host/app/components/module.gts
+++ b/host/app/components/module.gts
@@ -26,6 +26,6 @@ export default class Module extends Component<Signature> {
     if (this.args.file.state !== 'ready') {
       throw new Error(`the file ${this.args.file.url} is not open`);
     }
-    return new ModuleSyntax(this.args.file.content);
+    return new ModuleSyntax(this.args.file.content, new URL(this.args.file.url));
   }
 }

--- a/host/tests/integration/components/schema-test.gts
+++ b/host/tests/integration/components/schema-test.gts
@@ -374,6 +374,6 @@ async function getSchemaArgs(context: TestContext, adapter: TestRealmAdapter, re
   if (openFile.state !== "ready") {
     throw new Error(`could not open file ${openFile.url}`);
   }
-  let moduleSyntax = new ModuleSyntax(openFile.content);
+  let moduleSyntax = new ModuleSyntax(openFile.content, new URL(openFile.url));
   return { moduleSyntax, ref, openFile };
 }

--- a/host/tests/unit/search-index-test.ts
+++ b/host/tests/unit/search-index-test.ts
@@ -1136,7 +1136,7 @@ posts/ignore-me.gts
       } catch (err: any) {
         assert.strictEqual(
           err.message,
-          `Your filter refers to nonexistent field \"nonExistentField\" on type ${testModuleRealm}person/Person`
+          `Your filter refers to nonexistent field \"nonExistentField\" on type {\"module\":\"${testModuleRealm}person\",\"name\":\"Person\"}`
         );
       }
     });

--- a/host/tests/unit/search-index-test.ts
+++ b/host/tests/unit/search-index-test.ts
@@ -14,7 +14,7 @@ const paths = new RealmPaths(testRealmURL);
 const testModuleRealm = 'http://localhost:4201/test/';
 
 module('Unit | search-index', function (hooks) {
-  hooks.before(async function () {
+  hooks.beforeEach(async function () {
     Loader.destroy();
     Loader.addURLMapping(
       new URL(baseRealm.url),
@@ -227,8 +227,8 @@ module('Unit | search-index', function (hooks) {
     });
     assert.deepEqual(definition?.super, {
       type: 'exportedCard',
-      module: `${testRealmURL}person`,
-      name: 'Person',
+      module: `${testRealmURL}index`,
+      name: 'PersonCard',
     });
 
     assert.deepEqual(definition?.fields.get('lastName'), {
@@ -289,8 +289,8 @@ module('Unit | search-index', function (hooks) {
     });
     assert.deepEqual(definition?.super, {
       type: 'exportedCard',
-      module: `${testRealmURL}person`,
-      name: 'Person',
+      module: `${testRealmURL}index`,
+      name: 'PersonCard',
     });
 
     assert.deepEqual(definition?.fields.get('lastName'), {
@@ -340,10 +340,16 @@ module('Unit | search-index', function (hooks) {
       module: `${testRealmURL}person`,
       name: 'FancyPerson',
     });
+    // we did not go thru the loader to consume our super class because it's in
+    // the same module, so the loader never stamped it. This results in its
+    // super definitions getting the non-exported style card ref.
     assert.deepEqual(definition?.super, {
-      type: 'exportedCard',
-      module: `${testRealmURL}person`,
-      name: 'Person',
+      type: 'ancestorOf',
+      card: {
+        type: 'exportedCard',
+        module: `${testRealmURL}person`,
+        name: 'FancyPerson',
+      },
     });
     assert.deepEqual(definition?.fields.get('lastName'), {
       fieldType: 'contains',
@@ -504,30 +510,6 @@ module('Unit | search-index', function (hooks) {
     );
   });
 
-  test('full indexing ignores card source where super class is in a different realm, but the realm says that the export is not actually a card', async function (assert) {
-    let realm = TestRealm.create({
-      'person.gts': `
-        import { contains, field, NotACard } from 'https://cardstack.com/base/card-api';
-        import StringCard from 'https://cardstack.com/base/string';
-
-        export class FancyPerson extends NotACard {
-          @field favoriteColor = contains(StringCard);
-        }
-      `,
-    });
-    let indexer = realm.searchIndex;
-    await indexer.run();
-    assert.strictEqual(
-      await indexer.typeOf({
-        type: 'exportedCard',
-        module: 'person.gts',
-        name: 'FancyPerson',
-      }),
-      undefined,
-      'FancyPerson is not actually a card'
-    );
-  });
-
   test('full indexing discovers internal field cards that are consumed by an exported card', async function (assert) {
     let realm = TestRealm.create({
       'person.gts': `
@@ -594,54 +576,6 @@ module('Unit | search-index', function (hooks) {
         field: 'lastName',
       },
     });
-  });
-
-  test('full indexing ignores fields that are not actually fields', async function (assert) {
-    let realm = TestRealm.create({
-      'person.gts': `
-        import { contains, field, Card, notAFieldDecorator, notAFieldType } from 'https://cardstack.com/base/card-api';
-        import StringCard from 'https://cardstack.com/base/string';
-
-        class NotAFieldCard {}
-
-        export class Person extends Card {
-          @field firstName = contains(StringCard);
-          @field lastName = contains(NotAFieldCard);
-          @notAFieldDecorator notAField = contains(StringCard);
-          @field alsoNotAField = notAFieldType(StringCard);
-        }
-      `,
-    });
-    let indexer = realm.searchIndex;
-    await indexer.run();
-    let definition = await indexer.typeOf({
-      type: 'exportedCard',
-      module: 'person.gts',
-      name: 'Person',
-    });
-    assert.deepEqual(definition?.fields.get('firstName'), {
-      fieldType: 'contains',
-      fieldCard: {
-        type: 'exportedCard',
-        module: 'https://cardstack.com/base/string',
-        name: 'default',
-      },
-    });
-    assert.strictEqual(
-      definition?.fields.get('lastName'),
-      undefined,
-      'lastName field does not exist'
-    );
-    assert.strictEqual(
-      definition?.fields.get('notAField'),
-      undefined,
-      'notAField field does not exist'
-    );
-    assert.strictEqual(
-      definition?.fields.get('alsoNotAField'),
-      undefined,
-      'alsoNotAField field does not exist'
-    );
   });
 
   test("indexing identifies an instance's card references", async function (assert) {

--- a/realm-server/package.json
+++ b/realm-server/package.json
@@ -25,7 +25,7 @@
     "yargs": "^17.5.1"
   },
   "scripts": {
-    "test": "NODE_NO_WARNINGS=1 qunit --require ts-node/register tests/index.ts",
+    "test": "NODE_NO_WARNINGS=1 SUPPRESS_ERRORS=true qunit --require ts-node/register tests/index.ts",
     "start": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main",
     "start:base": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4201 --path='../base' --fromUrl='https://cardstack.com/base/' --toUrl='/base/'",
     "start:base-and-host-test-realms": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main --port=4201 --path='../base' --fromUrl='https://cardstack.com/base/' --toUrl='/base/' --path='../host/tests/cards' --fromUrl='/test/' --toUrl='/test/'",

--- a/realm-server/tests/module-syntax-test.ts
+++ b/realm-server/tests/module-syntax-test.ts
@@ -2,6 +2,8 @@ import { module, test } from "qunit";
 import { ModuleSyntax } from "@cardstack/runtime-common/module-syntax";
 import "@cardstack/runtime-common/helpers/code-equality-assertion";
 
+const testURL = new URL("http://test-realm/module");
+
 module("module-syntax", function () {
   test("can get the code for a card", async function (assert) {
     let src = `
@@ -16,7 +18,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, testURL);
     assert.codeEqual(mod.code(), src);
   });
 
@@ -33,7 +35,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, testURL);
     mod.addField(
       { type: "exportedName", name: "Person" },
       "age",
@@ -129,7 +131,7 @@ module("module-syntax", function () {
         export class Person extends Card { }
       `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, testURL);
     mod.addField(
       { type: "exportedName", name: "Person" },
       "firstName",
@@ -170,7 +172,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, testURL);
     mod.addField(
       { type: "localName", name: "Person" },
       "age",
@@ -216,7 +218,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, testURL);
     mod.addField(
       { type: "exportedName", name: "Person" },
       "aliases",
@@ -268,7 +270,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, testURL);
     mod.addField(
       { type: "exportedName", name: "Person" },
       "age",
@@ -308,7 +310,7 @@ module("module-syntax", function () {
         @field firstName = contains(StringCard);
       }
     `;
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, testURL);
     try {
       mod.addField(
         { type: "exportedName", name: "Person" },
@@ -338,7 +340,7 @@ module("module-syntax", function () {
         @field lastName = contains(StringCard);
       }
     `;
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, testURL);
     mod.removeField({ type: "exportedName", name: "Person" }, "firstName");
 
     assert.codeEqual(
@@ -368,7 +370,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, testURL);
     mod.removeField({ type: "exportedName", name: "Person" }, "firstName");
 
     assert.codeEqual(
@@ -394,7 +396,7 @@ module("module-syntax", function () {
         @field favoriteColor = contains(StringCard);
       }
     `;
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, testURL);
     mod.removeField({ type: "localName", name: "Person" }, "firstName");
 
     assert.codeEqual(
@@ -424,7 +426,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, testURL);
     try {
       mod.removeField({ type: "exportedName", name: "Person" }, "foo");
       throw new Error("expected error was not thrown");

--- a/realm-server/tests/realm-server-test.ts
+++ b/realm-server/tests/realm-server-test.ts
@@ -19,6 +19,7 @@ import {
 import { stringify } from "qs";
 import { NodeAdapter } from "../node-realm";
 import { Query } from "@cardstack/runtime-common/query";
+import "@cardstack/runtime-common/helpers/code-equality-assertion";
 
 setGracefulCleanup();
 const testRealmURL = new URL("http://127.0.0.1:4444/");
@@ -71,7 +72,7 @@ module("Realm Server", function (hooks) {
         },
         meta: {
           adoptsFrom: {
-            module: `${testRealmURL}person.gts`,
+            module: `${testRealmURL}person`,
             name: "Person",
           },
         },
@@ -175,7 +176,7 @@ module("Realm Server", function (hooks) {
             },
             meta: {
               adoptsFrom: {
-                module: `${testRealmHref}person.gts`,
+                module: `${testRealmHref}person`,
                 name: "Person",
               },
             },
@@ -255,16 +256,16 @@ module("Realm Server", function (hooks) {
     let response = await request
       .post("/unused-card.gts")
       .set("Accept", "application/vnd.card+source")
-      .send(`//TEST UPDATE ${cardSrc}`);
+      .send(`//TEST UPDATE\n${cardSrc}`);
     assert.strictEqual(response.status, 204, "HTTP 204 status");
 
     let srcFile = join(dir.name, "unused-card.gts");
     assert.ok(existsSync(srcFile), "card src exists");
     let src = readFileSync(srcFile, { encoding: "utf8" });
-    assert.strictEqual(
+    assert.codeEqual(
       src,
-      `//TEST UPDATE ${cardSrc}`,
-      "file contents are correct"
+      `//TEST UPDATE
+      ${cardSrc}`
     );
   });
 

--- a/runtime-common/index.ts
+++ b/runtime-common/index.ts
@@ -120,8 +120,11 @@ export {
   isCardSingleResourceDocument,
 } from "./search-index";
 
-// @ts-ignore
+// @ts-ignore tsc doesn't understand .gts files
+import type CardAPI from "https://cardstack.com/base/card-api";
+// @ts-ignore tsc doesn't understand .gts files
 import type { Card } from "https://cardstack.com/base/card-api";
+export { CardAPI, Card };
 
 export interface CardChooser {
   chooseCard<T extends Card>(query: Query): Promise<undefined | T>;
@@ -139,4 +142,22 @@ export async function chooseCard<T extends Card>(
   let chooser: CardChooser = here._CARDSTACK_CARD_CHOOSER;
 
   return await chooser.chooseCard<T>(query);
+}
+
+export function hasExecutableExtension(path: string): boolean {
+  for (let extension of executableExtensions) {
+    if (path.endsWith(extension)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function trimExecutableExtension(url: URL): URL {
+  for (let extension of executableExtensions) {
+    if (url.href.endsWith(extension)) {
+      return new URL(url.href.replace(new RegExp(`\\${extension}$`), ""));
+    }
+  }
+  return url;
 }

--- a/runtime-common/loader.ts
+++ b/runtime-common/loader.ts
@@ -1,6 +1,7 @@
 import TransformModulesAmdPlugin from "transform-modules-amd-plugin";
 import { transformSync } from "@babel/core";
 import { Deferred } from "./deferred";
+import { trimExecutableExtension } from "./index";
 import { RealmPaths, LocalPath } from "./paths";
 import type { Realm } from "./realm";
 
@@ -272,7 +273,9 @@ export class Loader {
         let value = Reflect.get(target, property, received);
         if (typeof value === "function" && typeof property === "string") {
           this.identities.set(value, {
-            module: this.reverseResolution(moduleIdentifier).href,
+            module: trimExecutableExtension(
+              this.reverseResolution(moduleIdentifier)
+            ).href,
             name: property,
           });
           Loader.loaders.set(value, this);

--- a/runtime-common/schema-analysis-plugin.ts
+++ b/runtime-common/schema-analysis-plugin.ts
@@ -38,6 +38,7 @@ export interface PossibleField {
 export interface Options {
   possibleCards: PossibleCardClass[];
   reexports: { exportName: string; ref: ExternalReference }[];
+  imports: ExternalReference[];
 }
 
 export function schemaAnalysisPlugin(_babel: typeof Babel) {
@@ -72,6 +73,14 @@ export function schemaAnalysisPlugin(_babel: typeof Babel) {
           if (specifier.type === "ImportNamespaceSpecifier") {
             continue;
           }
+          state.opts.imports.push({
+            type: "external",
+            module: path.node.source.value,
+            name:
+              specifier.type === "ImportDefaultSpecifier"
+                ? "default"
+                : getName(specifier.imported),
+          });
           let binding = specifier.local
             ? path.scope.getBinding(getName(specifier.local))
             : undefined;

--- a/runtime-common/search-index.ts
+++ b/runtime-common/search-index.ts
@@ -254,11 +254,6 @@ export class SearchIndex {
     return this.#currentRun.loader;
   }
 
-  // TODO delete this!
-  get currentRun() {
-    return this.#currentRun;
-  }
-
   async update(url: URL, opts?: { delete?: true }): Promise<void> {
     this.#currentRun = await CurrentRun.incremental(
       url,


### PR DESCRIPTION
This refactor focuses on leveraging card executables and their related Loader identities for indexing vs using module syntax analysis. Ultimately it was not possible to completely eliminate syntax analysis from the indexing, because when a card fails to load, we still need to fall back to syntax analysis to build the error document with the proper card references in order for the error documents to invalidate correctly. Consider a syntax error in a module that is consumed by other cards in another module. The consumers will fail to load, but not due to any issue in their own modules. This does mean though we don't have to perform module analysis on all the modules. Rather, we only perform module analysis on modules that fail to load. This did result in a great simplification of the definition building process, and a bunch of deleted code in the `ModuleSyntax` (specifically the `find()` method). Also, by using actual running cards to build the definitions that teased out a bunch of bugs that we had in our tests.