### PR TITLE
Refactor indexing to eliminate module syntax completely

### DIFF
--- a/host/app/components/module.gts
+++ b/host/app/components/module.gts
@@ -26,6 +26,6 @@ export default class Module extends Component<Signature> {
     if (this.args.file.state !== 'ready') {
       throw new Error(`the file ${this.args.file.url} is not open`);
     }
-    return new ModuleSyntax(this.args.file.content, new URL(this.args.file.url));
+    return new ModuleSyntax(this.args.file.content);
   }
 }

--- a/host/tests/integration/components/schema-test.gts
+++ b/host/tests/integration/components/schema-test.gts
@@ -376,6 +376,6 @@ async function getSchemaArgs(context: TestContext, adapter: TestRealmAdapter, re
   if (openFile.state !== "ready") {
     throw new Error(`could not open file ${openFile.url}`);
   }
-  let moduleSyntax = new ModuleSyntax(openFile.content, new URL(openFile.url));
+  let moduleSyntax = new ModuleSyntax(openFile.content);
   return { moduleSyntax, ref, openFile };
 }

--- a/realm-server/tests/cards/d.js
+++ b/realm-server/tests/cards/d.js
@@ -1,0 +1,5 @@
+import { e } from "./e";
+
+export function d() {
+  return e();
+}

--- a/realm-server/tests/cards/d.js
+++ b/realm-server/tests/cards/d.js
@@ -1,5 +1,6 @@
+import { a } from "./a";
 import { e } from "./e";
 
 export function d() {
-  return e();
+  return a() + e();
 }

--- a/realm-server/tests/cards/e.js
+++ b/realm-server/tests/cards/e.js
@@ -1,0 +1,1 @@
+throw new Error("intentional error thrown");

--- a/realm-server/tests/indexing-test.ts
+++ b/realm-server/tests/indexing-test.ts
@@ -163,7 +163,6 @@ module("indexing", function (hooks) {
         instancesIndexed: 1,
         definitionsBuilt: 0,
         instanceErrors: 0,
-        definitionErrors: 0,
         moduleErrors: 0,
       },
       "indexed correct number of files"
@@ -190,7 +189,6 @@ module("indexing", function (hooks) {
         instancesIndexed: 0,
         definitionsBuilt: 0,
         instanceErrors: 1,
-        definitionErrors: 1,
         moduleErrors: 1,
       },
       "indexed correct number of files"
@@ -208,7 +206,6 @@ module("indexing", function (hooks) {
         instancesIndexed: 0,
         definitionsBuilt: 0,
         instanceErrors: 3, // 1 post, 2 persons
-        definitionErrors: 2, // post, fancy person (person is not a def error because the syntax failed)
         moduleErrors: 3, // post, fancy person, person
       },
       "indexed correct number of files"
@@ -228,7 +225,6 @@ module("indexing", function (hooks) {
         "person card does not exist"
       );
     }
-
     await realm.write(
       "person.gts",
       `
@@ -246,7 +242,6 @@ module("indexing", function (hooks) {
         instancesIndexed: 3, // 1 post and 2 persons
         definitionsBuilt: 3, // person, fancy-person, post
         instanceErrors: 0,
-        definitionErrors: 0,
         moduleErrors: 0,
       },
       "indexed correct number of files"
@@ -279,7 +274,6 @@ module("indexing", function (hooks) {
         instancesIndexed: 0,
         definitionsBuilt: 0,
         instanceErrors: 0,
-        definitionErrors: 0,
         moduleErrors: 0,
       },
       "index did not touch any files"
@@ -319,7 +313,6 @@ module("indexing", function (hooks) {
         instancesIndexed: 1,
         definitionsBuilt: 1,
         instanceErrors: 0,
-        definitionErrors: 0,
         moduleErrors: 0,
       },
       "indexed correct number of files"
@@ -357,7 +350,6 @@ module("indexing", function (hooks) {
         instancesIndexed: 3,
         definitionsBuilt: 3,
         instanceErrors: 0,
-        definitionErrors: 0,
         moduleErrors: 0,
       },
       "indexed correct number of files"
@@ -385,13 +377,7 @@ module("indexing", function (hooks) {
         type: "error",
         error: {
           message: "CardError 404 (TODO include stack trace)",
-          errorReferences: [
-            {
-              type: "exportedCard",
-              module: "http://test-realm/post",
-              name: "Post",
-            },
-          ],
+          errorReferences: ["http://test-realm/post"],
         },
       },
       "card instance is an error document"
@@ -402,7 +388,6 @@ module("indexing", function (hooks) {
         instancesIndexed: 0,
         definitionsBuilt: 0,
         instanceErrors: 1,
-        definitionErrors: 0,
         moduleErrors: 0,
       },
       "indexed correct number of files"
@@ -440,7 +425,6 @@ module("indexing", function (hooks) {
         instancesIndexed: 1,
         definitionsBuilt: 1,
         instanceErrors: 0,
-        definitionErrors: 0,
         moduleErrors: 0,
       },
       "indexed correct number of files"

--- a/realm-server/tests/loader-test.ts
+++ b/realm-server/tests/loader-test.ts
@@ -41,11 +41,10 @@ module("loader", function () {
 
   test("can determine consumed modules", async function (assert) {
     let loader = new Loader();
-    let a = await loader.import<{ a(): string }>(`${testRealm}a`);
-    assert.deepEqual(loader.getConsumedModules(a), [
-      `${testRealm}a`,
-      `${testRealm}b`,
+    await loader.import<{ a(): string }>(`${testRealm}a`);
+    assert.deepEqual(await loader.getConsumedModules(`${testRealm}a`), [
       `${testRealm}c`,
+      `${testRealm}b`,
     ]);
   });
 
@@ -56,8 +55,10 @@ module("loader", function () {
       throw new Error(`expected error was not thrown`);
     } catch (e) {
       assert.strictEqual(e.message, "intentional error thrown");
-      assert.deepEqual(loader.getConsumedModules(e), [
-        `${testRealm}d`,
+      assert.deepEqual(await loader.getConsumedModules(`${testRealm}d`), [
+        `${testRealm}c`,
+        `${testRealm}b`,
+        `${testRealm}a`,
         `${testRealm}e`,
       ]);
     }

--- a/realm-server/tests/loader-test.ts
+++ b/realm-server/tests/loader-test.ts
@@ -39,6 +39,30 @@ module("loader", function () {
     assert.strictEqual(myLoader(), loader, "the loader instance is correct");
   });
 
+  test("can determine consumed modules", async function (assert) {
+    let loader = new Loader();
+    let a = await loader.import<{ a(): string }>(`${testRealm}a`);
+    assert.deepEqual(loader.getConsumedModules(a), [
+      `${testRealm}a`,
+      `${testRealm}b`,
+      `${testRealm}c`,
+    ]);
+  });
+
+  test("can determine consumed modules when an error is encountered during loading", async function (assert) {
+    let loader = new Loader();
+    try {
+      await loader.import<{ d(): string }>(`${testRealm}d`);
+      throw new Error(`expected error was not thrown`);
+    } catch (e) {
+      assert.strictEqual(e.message, "intentional error thrown");
+      assert.deepEqual(loader.getConsumedModules(e), [
+        `${testRealm}d`,
+        `${testRealm}e`,
+      ]);
+    }
+  });
+
   test("supports identify API", async function (assert) {
     let loader = new Loader();
     let { Person } = await loader.import<{ Person: unknown }>(

--- a/realm-server/tests/module-syntax-test.ts
+++ b/realm-server/tests/module-syntax-test.ts
@@ -2,8 +2,6 @@ import { module, test } from "qunit";
 import { ModuleSyntax } from "@cardstack/runtime-common/module-syntax";
 import "@cardstack/runtime-common/helpers/code-equality-assertion";
 
-const testURL = new URL("http://test-realm/module");
-
 module("module-syntax", function () {
   test("can get the code for a card", async function (assert) {
     let src = `
@@ -18,7 +16,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src, testURL);
+    let mod = new ModuleSyntax(src);
     assert.codeEqual(mod.code(), src);
   });
 
@@ -35,7 +33,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src, testURL);
+    let mod = new ModuleSyntax(src);
     mod.addField(
       { type: "exportedName", name: "Person" },
       "age",
@@ -131,7 +129,7 @@ module("module-syntax", function () {
         export class Person extends Card { }
       `;
 
-    let mod = new ModuleSyntax(src, testURL);
+    let mod = new ModuleSyntax(src);
     mod.addField(
       { type: "exportedName", name: "Person" },
       "firstName",
@@ -172,7 +170,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src, testURL);
+    let mod = new ModuleSyntax(src);
     mod.addField(
       { type: "localName", name: "Person" },
       "age",
@@ -218,7 +216,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src, testURL);
+    let mod = new ModuleSyntax(src);
     mod.addField(
       { type: "exportedName", name: "Person" },
       "aliases",
@@ -270,7 +268,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src, testURL);
+    let mod = new ModuleSyntax(src);
     mod.addField(
       { type: "exportedName", name: "Person" },
       "age",
@@ -310,7 +308,7 @@ module("module-syntax", function () {
         @field firstName = contains(StringCard);
       }
     `;
-    let mod = new ModuleSyntax(src, testURL);
+    let mod = new ModuleSyntax(src);
     try {
       mod.addField(
         { type: "exportedName", name: "Person" },
@@ -340,7 +338,7 @@ module("module-syntax", function () {
         @field lastName = contains(StringCard);
       }
     `;
-    let mod = new ModuleSyntax(src, testURL);
+    let mod = new ModuleSyntax(src);
     mod.removeField({ type: "exportedName", name: "Person" }, "firstName");
 
     assert.codeEqual(
@@ -370,7 +368,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src, testURL);
+    let mod = new ModuleSyntax(src);
     mod.removeField({ type: "exportedName", name: "Person" }, "firstName");
 
     assert.codeEqual(
@@ -396,7 +394,7 @@ module("module-syntax", function () {
         @field favoriteColor = contains(StringCard);
       }
     `;
-    let mod = new ModuleSyntax(src, testURL);
+    let mod = new ModuleSyntax(src);
     mod.removeField({ type: "localName", name: "Person" }, "firstName");
 
     assert.codeEqual(
@@ -426,7 +424,7 @@ module("module-syntax", function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src, testURL);
+    let mod = new ModuleSyntax(src);
     try {
       mod.removeField({ type: "exportedName", name: "Person" }, "foo");
       throw new Error("expected error was not thrown");

--- a/runtime-common/index.ts
+++ b/runtime-common/index.ts
@@ -111,8 +111,8 @@ export type {
   ExportedCardRef,
   CardResource,
   CardDocument,
-  CardDefinition,
 } from "./search-index";
+export type { CardDefinition } from "./current-run";
 export {
   isCardResource,
   isCardDocument,

--- a/runtime-common/loader.ts
+++ b/runtime-common/loader.ts
@@ -303,7 +303,7 @@ export class Loader {
     return absoluteURL;
   }
 
-  createModuleProxy(module: any, moduleIdentifier: string) {
+  private createModuleProxy(module: any, moduleIdentifier: string) {
     return new Proxy(module, {
       get: (target, property, received) => {
         let value = Reflect.get(target, property, received);

--- a/runtime-common/loader.ts
+++ b/runtime-common/loader.ts
@@ -60,7 +60,7 @@ export class Loader {
     Function,
     { module: string; name: string }
   >();
-  private trackedLoaders = new WeakMap<object, TrackedLoader>();
+  private trackedLoaders = new WeakMap<object | Error, TrackedLoader>();
 
   constructor() {}
 
@@ -211,8 +211,10 @@ export class Loader {
     let module: T;
     try {
       module = await trackedLoader.import(moduleIdentifier);
-    } catch (err) {
-      this.trackedLoaders.set(err, trackedLoader);
+    } catch (err: any) {
+      if (err instanceof Error) {
+        this.trackedLoaders.set(err, trackedLoader);
+      }
       throw err;
     }
     this.trackedLoaders.set(module, trackedLoader);

--- a/runtime-common/loader.ts
+++ b/runtime-common/loader.ts
@@ -172,10 +172,10 @@ export class Loader {
     let resolvedModuleIdentifier = this.resolve(new URL(moduleIdentifier));
     let module = this.modules.get(resolvedModuleIdentifier.href);
     if (!module || module.state === "fetching") {
-      // we haven't yet tried importing the module or we are still in teh process of importing the module
+      // we haven't yet tried importing the module or we are still in the process of importing the module
       try {
         await this.import(moduleIdentifier);
-      } catch (err) {
+      } catch (err: any) {
         console.warn(
           `encountered an error trying to load the module ${moduleIdentifier}. The consumedModule result includes all the known consumed modules including the module that caused the error: ${err.message}`
         );

--- a/runtime-common/realm.ts
+++ b/runtime-common/realm.ts
@@ -186,10 +186,7 @@ export class Realm {
     if (
       executableExtensions.some((extension) => handle.path.endsWith(extension))
     ) {
-      return await this.makeJS(
-        await this.fileContentToText(handle),
-        handle.path
-      );
+      return this.makeJS(await this.fileContentToText(handle), handle.path);
     } else {
       return await this.serveLocalFile(handle);
     }
@@ -310,16 +307,10 @@ export class Realm {
     })!.code!;
   }
 
-  private async makeJS(
-    content: string,
-    debugFilename: string
-  ): Promise<Response> {
+  private makeJS(content: string, debugFilename: string): Response {
     try {
       content = this.transpileJS(content, debugFilename);
     } catch (err: any) {
-      Promise.resolve().then(() => {
-        throw err;
-      });
       return new Response(err.message, {
         // using "Not Acceptable" here because no text/javascript representation
         // can be made and we're sending text/html error page instead

--- a/runtime-common/schema-analysis-plugin.ts
+++ b/runtime-common/schema-analysis-plugin.ts
@@ -37,79 +37,12 @@ export interface PossibleField {
 
 export interface Options {
   possibleCards: PossibleCardClass[];
-  reexports: { exportName: string; ref: ExternalReference }[];
-  imports: ExternalReference[];
 }
 
 export function schemaAnalysisPlugin(_babel: typeof Babel) {
   // let t = babel.types;
   return {
     visitor: {
-      ExportNamedDeclaration(
-        path: NodePath<t.ExportNamedDeclaration>,
-        state: State
-      ) {
-        // Handle reexports that are not in the module scope
-        if (path.node.source != null) {
-          for (let specifier of path.node.specifiers) {
-            if (specifier.type !== "ExportSpecifier") {
-              continue;
-            }
-            state.opts.reexports.push({
-              exportName: getName(specifier.exported),
-              ref: {
-                type: "external",
-                module: path.node.source.value,
-                name: specifier.local.name,
-              },
-            });
-          }
-        }
-      },
-
-      ImportDeclaration(path: NodePath<t.ImportDeclaration>, state: State) {
-        // Handle reexports that are in module scope
-        for (let specifier of path.node.specifiers) {
-          if (specifier.type === "ImportNamespaceSpecifier") {
-            continue;
-          }
-          state.opts.imports.push({
-            type: "external",
-            module: path.node.source.value,
-            name:
-              specifier.type === "ImportDefaultSpecifier"
-                ? "default"
-                : getName(specifier.imported),
-          });
-          let binding = specifier.local
-            ? path.scope.getBinding(getName(specifier.local))
-            : undefined;
-          if (!binding) {
-            continue;
-          }
-          let exportSpecifierLocal = binding.referencePaths.find((b) =>
-            b.parentPath?.isExportSpecifier()
-          ) as NodePath<t.Identifier> | undefined;
-          if (exportSpecifierLocal) {
-            let exportName = getName(
-              (exportSpecifierLocal.parentPath as NodePath<t.ExportSpecifier>)
-                .node.exported
-            );
-            state.opts.reexports.push({
-              exportName,
-              ref: {
-                type: "external",
-                module: path.node.source.value,
-                name:
-                  specifier.type === "ImportDefaultSpecifier"
-                    ? "default"
-                    : getName(specifier.imported),
-              },
-            });
-          }
-        }
-      },
-
       ClassDeclaration: {
         enter(path: NodePath<t.ClassDeclaration>, state: State) {
           if (!path.node.superClass) {

--- a/runtime-common/search-index.ts
+++ b/runtime-common/search-index.ts
@@ -1,6 +1,11 @@
 import { trimExecutableExtension, baseRealm } from ".";
 import { Kind, Realm } from "./realm";
-import { CurrentRun, SearchEntry, SearchEntryWithErrors } from "./current-run";
+import {
+  CurrentRun,
+  SearchEntry,
+  SearchEntryWithErrors,
+  CardDefinition,
+} from "./current-run";
 import { LocalPath } from "./paths";
 import { Query, Filter, Sort } from "./query";
 import flatMap from "lodash/flatMap";
@@ -202,19 +207,6 @@ export function isCardCollectionDocument(
     return false;
   }
   return data.every((resource) => isCardResource(resource));
-}
-
-export interface CardDefinition {
-  id: CardRef;
-  key: string; // this is used to help for JSON-API serialization
-  super: CardRef | undefined; // base card has no super
-  fields: Map<
-    string,
-    {
-      fieldType: "contains" | "containsMany";
-      fieldCard: CardRef;
-    }
-  >;
 }
 
 export class SearchIndex {


### PR DESCRIPTION
The layered loader idea seemed fundamentally opposed to module caching. The idea with the layered loader was that for each Loader.import() we track the module URL's that the loader processes as it winds thru the deps in a class that we would instantiate for each import (TrackedLoader) that shares a cache with all the loaders that we'd use for a current run of the indexer. The problem is that as soon as you decide to use a cached module, you can't see the work that was used to generate that module--and more over the work used to generate the module from a different import may actually include work that is not relevant to our own import depending on what you imported that generated the cached module. So instead, I used the other idea we discussed where each module knows it's direct dependencies (via the AMD eval's dependency list), and then you ask for the modules that were consumed for an import, we just recursively collect all those deps. that approach seems to work just fine with our caching and piggy backed really nicely with the AMD style loading.