### PR TITLE
add support for id's in card instances

### DIFF
--- a/host/app/resources/card-type.ts
+++ b/host/app/resources/card-type.ts
@@ -61,7 +61,7 @@ export class CardType extends Resource<Args> {
     }
 
     let api = await this.loader.import<CardAPI>(`${baseRealm.url}card-api`);
-    let fields = api.getFields(card);
+    let { id: remove, ...fields } = api.getFields(card);
     let superCard = Reflect.getPrototypeOf(card) as typeof Card | null;
     let superType: Type | undefined;
     if (superCard && card !== superCard) {

--- a/runtime-common/loader.ts
+++ b/runtime-common/loader.ts
@@ -239,9 +239,6 @@ export class Loader {
     let resolvedModule = this.resolve(moduleIdentifier);
     let resolvedModuleIdentifier = resolvedModule.href;
 
-    if (moduleIdentifier === "http://test-realm/test/test-cards") {
-      debugger;
-    }
     let shimmed = this.moduleShims.get(moduleIdentifier);
     if (shimmed) {
       return shimmed as T;


### PR DESCRIPTION
This PR introduces an `id` field to card instances by way of the base card including an `id` field. This PR also introduces a saved/unsaved state into the card instances via a symbol. When the instance is in an unsaved state, the id field can be set. When the instance is in a saved state, assignment of the `id` field will throw. A card is considered saved when it is deserialized from a resource object that includes an ID. Additionally, I added a `isSaved()` function to our API so that card instances's save state can be understood from outside of the card.