### PR TITLE
Fixes cycle bug in Loader.getConsumedModules()

### DIFF
--- a/realm-server/tests/loader-test.ts
+++ b/realm-server/tests/loader-test.ts
@@ -43,8 +43,9 @@ module("loader", function () {
     let loader = new Loader();
     await loader.import<{ a(): string }>(`${testRealm}a`);
     assert.deepEqual(await loader.getConsumedModules(`${testRealm}a`), [
-      `${testRealm}c`,
+      `${testRealm}a`,
       `${testRealm}b`,
+      `${testRealm}c`,
     ]);
   });
 
@@ -56,12 +57,23 @@ module("loader", function () {
     } catch (e) {
       assert.strictEqual(e.message, "intentional error thrown");
       assert.deepEqual(await loader.getConsumedModules(`${testRealm}d`), [
-        `${testRealm}c`,
-        `${testRealm}b`,
+        `${testRealm}d`,
         `${testRealm}a`,
+        `${testRealm}b`,
+        `${testRealm}c`,
         `${testRealm}e`,
       ]);
     }
+  });
+
+  test("can get consumed modules within a cycle", async function (assert) {
+    let loader = new Loader();
+    await loader.import<{ three(): number }>(`${testRealm}cycle-two`);
+    let modules = await loader.getConsumedModules(`${testRealm}cycle-two`);
+    assert.deepEqual(modules, [
+      `${testRealm}cycle-two`,
+      `${testRealm}cycle-one`,
+    ]);
   });
 
   test("supports identify API", async function (assert) {

--- a/runtime-common/current-run.ts
+++ b/runtime-common/current-run.ts
@@ -303,7 +303,9 @@ export class CurrentRun {
           `encountered error loading module "${url.href}": ${err.message}`
         );
       }
-      let errorReferences = await this.loader.getConsumedModules(url.href);
+      let errorReferences = await (
+        await this.loader.getConsumedModules(url.href)
+      ).filter((u) => u !== url.href);
       this.#modules.set(url.href, {
         type: "error",
         moduleURL: url.href,
@@ -383,7 +385,9 @@ export class CurrentRun {
           searchData,
           types: typesMaybeError.types,
           deps: new Set([
-            ...(await this.loader.getConsumedModules(moduleURL.href)),
+            ...(await this.loader.getConsumedModules(moduleURL.href)).filter(
+              (u) => u !== moduleURL.href
+            ),
             moduleURL.href,
           ]),
         },
@@ -444,7 +448,9 @@ export class CurrentRun {
         m[exportName];
       }
     }
-    let consumes = await this.loader.getConsumedModules(url);
+    let consumes = await (
+      await this.loader.getConsumedModules(url)
+    ).filter((u) => u !== url);
     let module: Module = {
       url,
       consumes,

--- a/runtime-common/loader.ts
+++ b/runtime-common/loader.ts
@@ -176,6 +176,7 @@ export class Loader {
     if (accumulator.has(moduleIdentifier)) {
       return [];
     }
+    accumulator.add(moduleIdentifier);
 
     let resolvedModuleIdentifier = this.resolve(new URL(moduleIdentifier));
     let module = this.modules.get(resolvedModuleIdentifier.href);

--- a/runtime-common/loader.ts
+++ b/runtime-common/loader.ts
@@ -202,7 +202,6 @@ export class Loader {
     }
     for (let consumed of module?.consumedModules ?? []) {
       await this.getConsumedModules(consumed, accumulator);
-      accumulator.add(consumed);
     }
     return [...accumulator];
   }

--- a/runtime-common/loader.ts
+++ b/runtime-common/loader.ts
@@ -171,12 +171,12 @@ export class Loader {
 
   async getConsumedModules(
     moduleIdentifier: string,
-    accumulator = new Set<string>()
+    consumed = new Set<string>()
   ): Promise<string[]> {
-    if (accumulator.has(moduleIdentifier)) {
+    if (consumed.has(moduleIdentifier)) {
       return [];
     }
-    accumulator.add(moduleIdentifier);
+    consumed.add(moduleIdentifier);
 
     let resolvedModuleIdentifier = this.resolve(new URL(moduleIdentifier));
     let module = this.modules.get(resolvedModuleIdentifier.href);
@@ -200,10 +200,10 @@ export class Loader {
         `bug: could not determine the consumed modules for ${moduleIdentifier} because it is still in "fetching" state`
       );
     }
-    for (let consumed of module?.consumedModules ?? []) {
-      await this.getConsumedModules(consumed, accumulator);
+    for (let consumedModule of module?.consumedModules ?? []) {
+      await this.getConsumedModules(consumedModule, consumed);
     }
-    return [...accumulator];
+    return [...consumed];
   }
 
   static identify(


### PR DESCRIPTION
The issue here was not actually the loader's import logic. Rather this was a bug in the `Loader.getConsumedModules()`, it was a simple case of not marking a module identifier as "visited" before the recursion into modules consumed by the module identifier you were asking about.