### PR TITLE
Update to render linksTo fields

### DIFF
--- a/base/card-api.gts
+++ b/base/card-api.gts
@@ -408,16 +408,8 @@ class Contains<CardT extends CardConstructor> implements Field<CardT> {
     return value;
   }
 
-  component(model: Box<Card>, format: Format) {
-    let fieldName = this.name as keyof Card;
-    let card: typeof Card;
-    if (primitive in this.card) {
-      card = this.card;
-    } else {
-      card = model.value[fieldName].constructor as typeof Card;
-    }
-    let innerModel = model.field(fieldName) as unknown as Box<Card>;
-    return getBoxComponent(card, format, innerModel);
+  component(model: Box<Card>, format: Format): ComponentLike<{ Args: {}, Blocks: {} }> {
+    return fieldComponent(this, model, format);
   }
 }
 
@@ -517,9 +509,21 @@ class LinksTo<CardT extends CardConstructor> implements Field<CardT> {
     return value;
   }
 
-  component(_model: Box<Card>, _format: Format): ComponentLike<{ Args: {}, Blocks: {} }> {
-    throw new Error('not implemented');
+  component(model: Box<Card>, format: Format): ComponentLike<{ Args: {}, Blocks: {} }> {
+    return fieldComponent(this, model, format);
   }
+}
+
+function fieldComponent(field: Field<typeof Card>, model: Box<Card>, format: Format): ComponentLike<{ Args: {}, Blocks: {} }> {
+  let fieldName = field.name as keyof Card;
+  let card: typeof Card;
+  if (primitive in field.card) {
+    card = field.card;
+  } else {
+    card = model.value[fieldName]?.constructor as typeof Card ?? field.card;
+  }
+  let innerModel = model.field(fieldName) as unknown as Box<Card>;
+  return getBoxComponent(card, format, innerModel);
 }
 
 // our decorators are implemented by Babel, not TypeScript, so they have a

--- a/host/tests/integration/components/catalog-entry-editor-test.gts
+++ b/host/tests/integration/components/catalog-entry-editor-test.gts
@@ -90,7 +90,8 @@ module('Integration | catalog-entry-editor', function (hooks) {
 
     assert.shadowDOM('[data-test-catalog-entry-editor] [data-test-field="title"] input').hasValue('Pet');
     assert.shadowDOM('[data-test-catalog-entry-editor] [data-test-field="description"] input').hasValue('Catalog entry for Pet card');
-    assert.shadowDOM('[data-test-catalog-entry-editor] [data-test-ref]').containsText(`Module: ${testRealmURL}pet Name: Pet`);
+    assert.shadowDOM('[data-test-ref]').exists();
+    assert.shadowDOM('[data-test-ref]').containsText(`Module: ${testRealmURL}pet Name: Pet`);
     assert.shadowDOM('[data-test-field="demo"] [data-test-field="name"] input').hasText('');
     assert.shadowDOM('[data-test-field="demo"] [data-test-field="lovesWalks"] label:nth-of-type(2) input').isChecked();
 
@@ -203,7 +204,8 @@ module('Integration | catalog-entry-editor', function (hooks) {
     assert.dom('[data-test-catalog-entry-id]').hasText(`${testRealmURL}pet-catalog-entry`);
     assert.shadowDOM('[data-test-catalog-entry-editor] [data-test-field="title"] input').hasValue('Pet');
     assert.shadowDOM('[data-test-catalog-entry-editor] [data-test-field="description"] input').hasValue('Catalog entry');
-    assert.shadowDOM('[data-test-catalog-entry-editor] [data-test-ref]').containsText(`Module: ${testRealmURL}pet Name: Pet`);
+    assert.shadowDOM('[data-test-ref]').exists();
+    assert.shadowDOM('[data-test-ref]').containsText(`Module: ${testRealmURL}pet Name: Pet`);
     assert.shadowDOM('[data-test-field="demo"] [data-test-field="name"] input').hasValue('Jackie');
     assert.shadowDOM('[data-test-field="demo"] [data-test-field="lovesWalks"] label:nth-of-type(1) input').isChecked();
     assert.shadowDOM('[data-test-field="demo"] [data-test-field="owner"] [data-test-field="firstName"] input').hasValue('BN');

--- a/host/tests/integration/components/computed-test.gts
+++ b/host/tests/integration/components/computed-test.gts
@@ -436,6 +436,7 @@ module('Integration | computeds', function (hooks) {
 
     let person = new Person({ firstName: 'Mango' });
     await renderCard(person, 'edit');
+    assert.shadowDOM('[data-test-field=alias]').exists();
     assert.shadowDOM('[data-test-field=alias]').containsText('Mango');
     assert.shadowDOM('[data-test-field=alias] input').doesNotExist('input field not rendered for computed')
   });
@@ -446,7 +447,7 @@ module('Integration | computeds', function (hooks) {
     class Location extends Card {
       @field city = contains(StringCard);
       static embedded = class Embedded extends Component<typeof this> {
-        <template><span><@fields.city/></span></template>
+        <template><span data-test-location><@fields.city/></span></template>
       }
     }
     class Person extends Card {
@@ -491,6 +492,7 @@ module('Integration | computeds', function (hooks) {
      }, undefined);
 
     await renderCard(person, 'edit');
+    assert.shadowDOM('[data-test-field="slowName"]').exists();
     assert.shadowDOM('[data-test-field="slowName"]').containsText('Mango');
     await fillIn('[data-test-field="firstName"] input', 'Van Gogh');
     // We want to ensure data consistency, so that when the template rerenders,
@@ -498,14 +500,18 @@ module('Integration | computeds', function (hooks) {
     await waitUntil(() =>
       shadowQuerySelector('[data-test-dep-field="firstName"]')?.textContent?.includes('Van Gogh')
     );
+    assert.shadowDOM('[data-test-field="slowName"]').exists();
     assert.shadowDOM('[data-test-field="slowName"]').containsText('Van Gogh');
 
-    assert.shadowDOM('[data-test-field="slowHomeTown"] span').containsText('Bronxville');
+    // this targets the slowHomeTown field which is the only Location card rendered in a nested shadow root
+    assert.shadowDOM('[data-test-location]').exists();
+    assert.shadowDOM('[data-test-location]').containsText('Bronxville');
     await fillIn('[data-test-field="homeTown"] input', 'Scarsdale');
     await waitUntil(() =>
       shadowQuerySelector('[data-test-dep-field="homeTown"]')?.textContent?.includes('Scarsdale')
     );
-    assert.shadowDOM('[data-test-field="slowHomeTown"] span').containsText('Scarsdale');
+    assert.shadowDOM('[data-test-location]').exists();
+    assert.shadowDOM('[data-test-location]').containsText('Scarsdale');
   });
 
   skip('can render a computed linksTo relationship');


### PR DESCRIPTION
 also addressed issue with inadvertently skipped tests. When `shadowRoot(...).containsText(...)` cannot find the element the test is skipped (!!!). I paired all the `.containsText()` with an `.exists()` and found some broken tests that were being skipped over