### PR TITLE
Harmonize tsconfig to unbreak main CI

### DIFF
--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -7,7 +7,7 @@
     "moduleResolution": "Node",
     "pretty": true,
     "target": "ES6",
-    "strict": true,
+    "strict": false,
     "sourceMap": true,
     "experimentalDecorators": true,
     "allowUnreachableCode": false,


### PR DESCRIPTION
Some packages use `strict` and some don't, this standardizes on not using it for now. A followup should turn it on everywhere.